### PR TITLE
adds options to handle junk data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ MODULE_big   = $(EXTENSION)
 OBJS         =  $(patsubst %.c,%.o,$(wildcard src/*.c))
 PG_CONFIG   ?= pg_config
 PG_CPPFLAGS  = -std=c99 -Wall -Wextra -Wno-unused-parameter
+
+ifndef NOINIT
 REGRESS_PREP = prep_kafka
+endif
 
 ifdef DEBUG
 PG_CPPFLAGS+= -DDO_DEBUG

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ With the defined meta columns you can query like so:
 SELECT * FROM kafka_test WHERE part = 0 AND offs > 1000 LIMIT 60;
 ```
 
+## Error handling
+
+The default for consuming kafka data is not very strict i.e. to less columns
+will be assumed be NULL and to many will be ignored.
+If you don't like this behaviour you can enable strictness via table options
+`strict 'true'`. Thus any such column will error out the query.
+However invalid or unparsable data e.g. text for numeric data or invalid date
+or such will still error out per default. To ignore such data you can pass
+`ignore_junk 'true'` as table options and these columns will be set to NULL.
+Alternatively you can add table columns with the attributes
+`junk 'true'` and / or `junk_error 'true'`. While fetching data kafka_fdw
+will then put the whole payload into the junk column and / or the errormessage(s)
+into the junk_error column.
+see test/sql/junk_test.sql for a usage example.
+
+
 ## Producing
 
 Inserting Data into kafak works with INSERT statements. If you provide the partition

--- a/test/expected/1_setup.out
+++ b/test/expected/1_setup.out
@@ -1,0 +1,4 @@
+CREATE SERVER kafka_server
+FOREIGN DATA WRAPPER kafka_fdw
+OPTIONS (brokers 'localhost:9092');
+CREATE USER MAPPING FOR PUBLIC SERVER kafka_server;

--- a/test/expected/junk_test.out
+++ b/test/expected/junk_test.out
@@ -11,106 +11,105 @@ CREATE FOREIGN TABLE kafka_test_junk (
 SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100');
 \x on
-SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0;
--[ RECORD 1 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 0
-some_int  | 91
-some_text | correct line
-some_date | 01-01-2015
-some_time | Thu Jan 01 01:31:00 2015
-junk      | 
-junk_err  | 
--[ RECORD 2 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 1
-some_int  | 131
-some_text | additional data
-some_date | 01-01-2015
-some_time | Thu Jan 01 02:11:00 2015
-junk      | 131,"additional data",01-01-2015,Thu Jan 01 02:11:00 2015,aditional data
-junk_err  | extra data after last expected column
--[ RECORD 3 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 2
-some_int  | 161
-some_text | additional data although null
-some_date | 01-01-2015
-some_time | Thu Jan 01 02:41:00 2015
-junk      | 161,"additional data although null",01-01-2015,Thu Jan 01 02:41:00 2015,
-junk_err  | extra data after last expected column
--[ RECORD 4 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 3
-some_int  | 301
-some_text | correct line although last line null
-some_date | 01-01-2015
-some_time | 
-junk      | 
-junk_err  | 
--[ RECORD 5 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 4
-some_int  | 371
-some_text | invalidat date
-some_date | 
-some_time | Thu Jan 01 06:11:00 2015
-junk      | 371,"invalidat date",invalid_date,Thu Jan 01 06:11:00 2015
-junk_err  | invalid input syntax for type date: "invalid_date"
--[ RECORD 6 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 5
-some_int  | 401
-some_text | unterminated string
-some_date | 
-some_time | 
-junk      | 401,"unterminated string","01-01-2015,Thu Jan 01 06:41:00 2015
-junk_err  | unterminated CSV quoted field
--[ RECORD 7 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 6
-some_int  | 421
-some_text | correct line
-some_date | 01-01-2015
-some_time | Thu Jan 01 07:01:00 2015
-junk      | 
-junk_err  | 
--[ RECORD 8 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 7
-some_int  | 
-some_text | invalid number
-some_date | 01-01-2015
-some_time | Thu Jan 01 07:11:00 2015
-junk      | 999999999999999,"invalid number",01-01-2015,Thu Jan 01 07:11:00 2015
-junk_err  | value "999999999999999" is out of range for type integer
--[ RECORD 9 ]-----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 8
-some_int  | 521
-some_text | correct line
-some_date | 01-01-2015
-some_time | Thu Jan 01 08:41:00 2015
-junk      | 
-junk_err  | 
--[ RECORD 10 ]----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 9
-some_int  | 
-some_text | invalid number, invalid date and extra data
-some_date | 
-some_time | Thu Jan 01 09:31:00 2015
-junk      | foo,"invalid number, invalid date and extra data",20-20-2015,Thu Jan 01 09:31:00 2015,extra data
-junk_err  | extra data after last expected column                                                           +
-          | invalid input syntax for integer: "foo"                                                         +
-          | date/time field value out of range: "20-20-2015"
--[ RECORD 11 ]----------------------------------------------------------------------------------------------
-part      | 0
-offs      | 10
-some_int  | 
-some_text | 
-some_date | 
-some_time | 
-junk      | "401,unterminated string,01-01-2015,Thu Jan 01 06:41:00 2015
-junk_err  | unterminated CSV quoted field
+with kafkadata as ( SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0 )
+SELECT part, offs, some_int, some_text, some_date, some_time, junk, string_to_array(junk_err, E'\n')  FROM kafkadata;
+-[ RECORD 1 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 0
+some_int        | 91
+some_text       | correct line
+some_date       | 01-01-2015
+some_time       | Thu Jan 01 01:31:00 2015
+junk            | 
+string_to_array | 
+-[ RECORD 2 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 1
+some_int        | 131
+some_text       | additional data
+some_date       | 01-01-2015
+some_time       | Thu Jan 01 02:11:00 2015
+junk            | 131,"additional data",01-01-2015,Thu Jan 01 02:11:00 2015,aditional data
+string_to_array | {"extra data after last expected column"}
+-[ RECORD 3 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 2
+some_int        | 161
+some_text       | additional data although null
+some_date       | 01-01-2015
+some_time       | Thu Jan 01 02:41:00 2015
+junk            | 161,"additional data although null",01-01-2015,Thu Jan 01 02:41:00 2015,
+string_to_array | {"extra data after last expected column"}
+-[ RECORD 4 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 3
+some_int        | 301
+some_text       | correct line although last line null
+some_date       | 01-01-2015
+some_time       | 
+junk            | 
+string_to_array | 
+-[ RECORD 5 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 4
+some_int        | 371
+some_text       | invalidat date
+some_date       | 
+some_time       | Thu Jan 01 06:11:00 2015
+junk            | 371,"invalidat date",invalid_date,Thu Jan 01 06:11:00 2015
+string_to_array | {"invalid input syntax for type date: \"invalid_date\""}
+-[ RECORD 6 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 5
+some_int        | 401
+some_text       | unterminated string
+some_date       | 
+some_time       | 
+junk            | 401,"unterminated string","01-01-2015,Thu Jan 01 06:41:00 2015
+string_to_array | {"unterminated CSV quoted field"}
+-[ RECORD 7 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 6
+some_int        | 421
+some_text       | correct line
+some_date       | 01-01-2015
+some_time       | Thu Jan 01 07:01:00 2015
+junk            | 
+string_to_array | 
+-[ RECORD 8 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 7
+some_int        | 
+some_text       | invalid number
+some_date       | 01-01-2015
+some_time       | Thu Jan 01 07:11:00 2015
+junk            | 999999999999999,"invalid number",01-01-2015,Thu Jan 01 07:11:00 2015
+string_to_array | {"value \"999999999999999\" is out of range for type integer"}
+-[ RECORD 9 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 8
+some_int        | 521
+some_text       | correct line
+some_date       | 01-01-2015
+some_time       | Thu Jan 01 08:41:00 2015
+junk            | 
+string_to_array | 
+-[ RECORD 10 ]--+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 9
+some_int        | 
+some_text       | invalid number, invalid date and extra data
+some_date       | 
+some_time       | Thu Jan 01 09:31:00 2015
+junk            | foo,"invalid number, invalid date and extra data",20-20-2015,Thu Jan 01 09:31:00 2015,extra data
+string_to_array | {"extra data after last expected column","invalid input syntax for integer: \"foo\"","date/time field value out of range: \"20-20-2015\""}
+-[ RECORD 11 ]--+-------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 10
+some_int        | 
+some_text       | 
+some_date       | 
+some_time       | 
+junk            | "401,unterminated string,01-01-2015,Thu Jan 01 06:41:00 2015
+string_to_array | {"unterminated CSV quoted field"}
 

--- a/test/expected/junk_test.out
+++ b/test/expected/junk_test.out
@@ -1,0 +1,116 @@
+CREATE FOREIGN TABLE kafka_test_junk (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp,
+    junk text OPTIONS (junk 'true'),
+    junk_err text OPTIONS (junk_error 'true')
+)
+SERVER kafka_server OPTIONS
+    (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100');
+\x on
+SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0;
+-[ RECORD 1 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 0
+some_int  | 91
+some_text | correct line
+some_date | 01-01-2015
+some_time | Thu Jan 01 01:31:00 2015
+junk      | 
+junk_err  | 
+-[ RECORD 2 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 1
+some_int  | 131
+some_text | additional data
+some_date | 01-01-2015
+some_time | Thu Jan 01 02:11:00 2015
+junk      | 131,"additional data",01-01-2015,Thu Jan 01 02:11:00 2015,aditional data
+junk_err  | extra data after last expected column
+-[ RECORD 3 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 2
+some_int  | 161
+some_text | additional data although null
+some_date | 01-01-2015
+some_time | Thu Jan 01 02:41:00 2015
+junk      | 161,"additional data although null",01-01-2015,Thu Jan 01 02:41:00 2015,
+junk_err  | extra data after last expected column
+-[ RECORD 4 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 3
+some_int  | 301
+some_text | correct line although last line null
+some_date | 01-01-2015
+some_time | 
+junk      | 
+junk_err  | 
+-[ RECORD 5 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 4
+some_int  | 371
+some_text | invalidat date
+some_date | 
+some_time | Thu Jan 01 06:11:00 2015
+junk      | 371,"invalidat date",invalid_date,Thu Jan 01 06:11:00 2015
+junk_err  | invalid input syntax for type date: "invalid_date"
+-[ RECORD 6 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 5
+some_int  | 401
+some_text | unterminated string
+some_date | 
+some_time | 
+junk      | 401,"unterminated string","01-01-2015,Thu Jan 01 06:41:00 2015
+junk_err  | unterminated CSV quoted field
+-[ RECORD 7 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 6
+some_int  | 421
+some_text | correct line
+some_date | 01-01-2015
+some_time | Thu Jan 01 07:01:00 2015
+junk      | 
+junk_err  | 
+-[ RECORD 8 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 7
+some_int  | 
+some_text | invalid number
+some_date | 01-01-2015
+some_time | Thu Jan 01 07:11:00 2015
+junk      | 999999999999999,"invalid number",01-01-2015,Thu Jan 01 07:11:00 2015
+junk_err  | value "999999999999999" is out of range for type integer
+-[ RECORD 9 ]-----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 8
+some_int  | 521
+some_text | correct line
+some_date | 01-01-2015
+some_time | Thu Jan 01 08:41:00 2015
+junk      | 
+junk_err  | 
+-[ RECORD 10 ]----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 9
+some_int  | 
+some_text | invalid number, invalid date and extra data
+some_date | 
+some_time | Thu Jan 01 09:31:00 2015
+junk      | foo,"invalid number, invalid date and extra data",20-20-2015,Thu Jan 01 09:31:00 2015,extra data
+junk_err  | extra data after last expected column                                                           +
+          | invalid input syntax for integer: "foo"                                                         +
+          | date/time field value out of range: "20-20-2015"
+-[ RECORD 11 ]----------------------------------------------------------------------------------------------
+part      | 0
+offs      | 10
+some_int  | 
+some_text | 
+some_date | 
+some_time | 
+junk      | "401,unterminated string,01-01-2015,Thu Jan 01 06:41:00 2015
+junk_err  | unterminated CSV quoted field
+

--- a/test/expected/kafka_test.out
+++ b/test/expected/kafka_test.out
@@ -1,8 +1,4 @@
 -- standard setup
-CREATE SERVER kafka_server
-FOREIGN DATA WRAPPER kafka_fdw
-OPTIONS (brokers 'localhost:9092');
-CREATE USER MAPPING FOR PUBLIC SERVER kafka_server;
 CREATE FOREIGN TABLE kafka_test_part (
     part int OPTIONS (partition 'true'),
     offs bigint OPTIONS (offset 'true'),

--- a/test/expected/producer_test.out
+++ b/test/expected/producer_test.out
@@ -104,7 +104,7 @@ SELECT i,
     'It''s some text, that is for number '||i,
     ('2015-01-01'::date + (i || ' minutes')::interval)::date,
     ('2015-01-01'::date + (i || ' minutes')::interval)::timestamp
-FROM generate_series(1,1e6::int, 10) i ORDER BY i;
+FROM generate_series(1,1e4::int, 10) i ORDER BY i;
 --- check total was inserted
 SELECT SUM(count) FROM(
 SELECT COUNT(*) FROM kafka_test_prod WHERE offs >= 0 and part=0
@@ -115,31 +115,31 @@ SELECT COUNT(*) FROM kafka_test_prod WHERE offs >= 0 and part=2
 UNION ALL
 SELECT COUNT(*) FROM kafka_test_prod WHERE offs >= 0 and part=3
 )t;
-  sum   
---------
- 100010
+ sum  
+------
+ 1010
 (1 row)
 
 --- check auto distribution makes sense
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=0;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=0;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=1;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=2;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=2;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=3;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=3;
  ?column? 
 ----------
  t
@@ -147,16 +147,16 @@ SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and
 
 --- check data is readable
 SELECT some_int, some_text, some_date FROM(
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=0 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=0 AND some_int = 231 LIMIT 1)
 UNION ALL
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=1 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=1 AND some_int = 231 LIMIT 1)
 UNION ALL
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=2 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=2 AND some_int = 231 LIMIT 1)
 UNION ALL
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=3 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=3 AND some_int = 231 LIMIT 1)
 )t;
- some_int |                some_text                 | some_date  
-----------+------------------------------------------+------------
-    10031 | It's some text, that is for number 10031 | 01-07-2015
+ some_int |               some_text                | some_date  
+----------+----------------------------------------+------------
+      231 | It's some text, that is for number 231 | 01-01-2015
 (1 row)
 

--- a/test/expected/strict_test.out
+++ b/test/expected/strict_test.out
@@ -1,0 +1,38 @@
+CREATE FOREIGN TABLE kafka_strict (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', strict 'true');
+SELECT * FROM kafka_strict WHERE offs>=0 and part=0;
+ERROR:  extra data after last expected column
+CREATE FOREIGN TABLE kafka_ignore_junk (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', ignore_junk 'true');
+SELECT * FROM kafka_ignore_junk WHERE offs>=0 and part=0;
+ part | offs | some_int |                  some_text                  | some_date  |        some_time         
+------+------+----------+---------------------------------------------+------------+--------------------------
+    0 |    0 |       91 | correct line                                | 01-01-2015 | Thu Jan 01 01:31:00 2015
+    0 |    1 |      131 | additional data                             | 01-01-2015 | Thu Jan 01 02:11:00 2015
+    0 |    2 |      161 | additional data although null               | 01-01-2015 | Thu Jan 01 02:41:00 2015
+    0 |    3 |      301 | correct line although last line null        | 01-01-2015 | 
+    0 |    4 |      371 | invalidat date                              |            | Thu Jan 01 06:11:00 2015
+    0 |    5 |      401 | unterminated string                         |            | 
+    0 |    6 |      421 | correct line                                | 01-01-2015 | Thu Jan 01 07:01:00 2015
+    0 |    7 |          | invalid number                              | 01-01-2015 | Thu Jan 01 07:11:00 2015
+    0 |    8 |      521 | correct line                                | 01-01-2015 | Thu Jan 01 08:41:00 2015
+    0 |    9 |          | invalid number, invalid date and extra data |            | Thu Jan 01 09:31:00 2015
+    0 |   10 |          |                                             |            | 
+(11 rows)
+

--- a/test/init_kafka.sh
+++ b/test/init_kafka.sh
@@ -6,11 +6,12 @@
 topic_part4="contrib_regress4"
 simple_topic="contrib_regress"
 prod_topic="contrib_regress_prod"
+junk_topic="contrib_regress_junk"
 out_sql="SELECT i, 'It''s some text, that is for number '||i, ('2015-01-01'::date + (i || ' seconds')::interval)::date, ('2015-01-01'::date + (i || ' seconds')::interval)::timestamp FROM generate_series(1,1e6::int, 10) i ORDER BY i"
 kafka_cmd="$KAFKA_PRODUCER --broker-list localhost:9092 --topic"
 
 # delete topic if it might exist
-for t in $simple_topic $topic_part4 $prod_topic; do
+for t in $simple_topic $topic_part4 $prod_topic $junk_topic; do
     $KAFKA_TOPICS --zookeeper localhost:2181 --delete --topic ${t}
 done
 sleep 2
@@ -19,8 +20,23 @@ sleep 2
 $KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${simple_topic} --partitions 1 --replication-factor 1
 $KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${topic_part4} --partitions 4 --replication-factor 1
 $KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${prod_topic} --partitions 4 --replication-factor 1
+$KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${junk_topic} --partitions 1 --replication-factor 1
 
 # write some test data to topicc
 for t in $simple_topic $topic_part4; do
 	psql -c "COPY(${out_sql}) TO STDOUT (FORMAT CSV);" -d postgres -p $PG_PORT -o "| ${kafka_cmd} ${t}" >/dev/null
 done;
+
+$kafka_cmd $junk_topic <<-EOF
+91,"correct line",01-01-2015,Thu Jan 01 01:31:00 2015
+131,"additional data",01-01-2015,Thu Jan 01 02:11:00 2015,aditional data
+161,"additional data although null",01-01-2015,Thu Jan 01 02:41:00 2015,
+301,"correct line although last line null",01-01-2015,
+371,"invalidat date",invalid_date,Thu Jan 01 06:11:00 2015
+401,"unterminated string","01-01-2015,Thu Jan 01 06:41:00 2015
+421,"correct line",01-01-2015,Thu Jan 01 07:01:00 2015
+999999999999999,"invalid number",01-01-2015,Thu Jan 01 07:11:00 2015
+521,"correct line",01-01-2015,Thu Jan 01 08:41:00 2015
+foo,"invalid number, invalid date and extra data",20-20-2015,Thu Jan 01 09:31:00 2015,extra data
+"401,unterminated string,01-01-2015,Thu Jan 01 06:41:00 2015
+EOF

--- a/test/sql/1_setup.sql
+++ b/test/sql/1_setup.sql
@@ -1,0 +1,5 @@
+CREATE SERVER kafka_server
+FOREIGN DATA WRAPPER kafka_fdw
+OPTIONS (brokers 'localhost:9092');
+
+CREATE USER MAPPING FOR PUBLIC SERVER kafka_server;

--- a/test/sql/junk_test.sql
+++ b/test/sql/junk_test.sql
@@ -1,0 +1,15 @@
+CREATE FOREIGN TABLE kafka_test_junk (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp,
+    junk text OPTIONS (junk 'true'),
+    junk_err text OPTIONS (junk_error 'true')
+)
+SERVER kafka_server OPTIONS
+    (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100');
+
+\x on
+SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0;

--- a/test/sql/junk_test.sql
+++ b/test/sql/junk_test.sql
@@ -12,4 +12,5 @@ SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100');
 
 \x on
-SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0;
+with kafkadata as ( SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0 )
+SELECT part, offs, some_int, some_text, some_date, some_time, junk, string_to_array(junk_err, E'\n')  FROM kafkadata;

--- a/test/sql/kafka_test.sql
+++ b/test/sql/kafka_test.sql
@@ -1,10 +1,4 @@
 -- standard setup
-CREATE SERVER kafka_server
-FOREIGN DATA WRAPPER kafka_fdw
-OPTIONS (brokers 'localhost:9092');
-
-CREATE USER MAPPING FOR PUBLIC SERVER kafka_server;
-
 CREATE FOREIGN TABLE kafka_test_part (
     part int OPTIONS (partition 'true'),
     offs bigint OPTIONS (offset 'true'),

--- a/test/sql/producer_test.sql
+++ b/test/sql/producer_test.sql
@@ -43,7 +43,7 @@ SELECT i,
     'It''s some text, that is for number '||i,
     ('2015-01-01'::date + (i || ' minutes')::interval)::date,
     ('2015-01-01'::date + (i || ' minutes')::interval)::timestamp
-FROM generate_series(1,1e6::int, 10) i ORDER BY i;
+FROM generate_series(1,1e4::int, 10) i ORDER BY i;
 
 
 --- check total was inserted
@@ -58,19 +58,19 @@ SELECT COUNT(*) FROM kafka_test_prod WHERE offs >= 0 and part=3
 )t;
 
 --- check auto distribution makes sense
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=0;
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=1;
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=2;
-SELECT COUNT(*) BETWEEN 10000 AND 30000 FROM kafka_test_prod WHERE offs >= 0 and part=3;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=0;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=1;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=2;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod WHERE offs >= 0 and part=3;
 
 
 --- check data is readable
 SELECT some_int, some_text, some_date FROM(
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=0 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=0 AND some_int = 231 LIMIT 1)
 UNION ALL
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=1 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=1 AND some_int = 231 LIMIT 1)
 UNION ALL
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=2 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=2 AND some_int = 231 LIMIT 1)
 UNION ALL
-(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=3 AND some_int = 10031 LIMIT 1)
+(SELECT some_int, some_text, some_date FROM kafka_test_prod WHERE offs >= 0 and part=3 AND some_int = 231 LIMIT 1)
 )t;

--- a/test/sql/strict_test.sql
+++ b/test/sql/strict_test.sql
@@ -1,0 +1,26 @@
+CREATE FOREIGN TABLE kafka_strict (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', strict 'true');
+
+SELECT * FROM kafka_strict WHERE offs>=0 and part=0;
+
+CREATE FOREIGN TABLE kafka_ignore_junk (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', ignore_junk 'true');
+
+SELECT * FROM kafka_ignore_junk WHERE offs>=0 and part=0;
+


### PR DESCRIPTION
Table options:
- strict (error out when payload doesn't match expected number or columns)
- ignore_junk (ignore unparsable fields)

Attribute options:
- junk (message payload of erroneous data )
- junk_error (error messages )

see
-  test/expected/strict_test.out
-  test/expected/junk_test.out

for examples