### PR TITLE
adds json support for reading and writing

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -46,6 +46,7 @@ static const struct KafkaFdwOption valid_options[] = {
     { "partition", AttributeRelationId, false },
     { "junk", AttributeRelationId, false },
     { "junk_error", AttributeRelationId, false },
+    { "json", AttributeRelationId, false },
     /*
      * force_quote is not supported by kafka_fdw because it's for COPY TO for now.
      */
@@ -160,11 +161,12 @@ KafkaProcessParseOptions(ParseOptions *parse_options, List *options)
                 /* default format */;
             else if (strcmp(fmt, "csv") == 0)
                 parse_options->csv_mode = true;
+            else if (strcmp(fmt, "json") == 0)
+                parse_options->json_mode = true;
             else if (strcmp(fmt, "binary") == 0)
                 parse_options->binary = true;
             else
-                ereport(ERROR,
-                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("COPY format \"%s\" not recognized", fmt)));
+                ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("format \"%s\" not recognized", fmt)));
         }
         else if (strcmp(defel->defname, "delimiter") == 0)
         {
@@ -341,7 +343,6 @@ is_valid_option(const char *option, Oid context)
 
 /*
  * Separate out brokers, topic and column-specific options, since
- * ProcessCopyOptions won't accept them.
  */
 void
 KafkaProcessKafkaOptions(Oid relid, KafkaOptions *kafka_options, List *options)

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,5 +1,56 @@
 #include "kafka_fdw.h"
+#include "parser/parse_coerce.h"
+#include "utils/date.h"
+#include "utils/datetime.h"
+#include "utils/json.h"
+#include "utils/jsonapi.h"
+#include "utils/lsyscache.h"
+#include "utils/typcache.h"
 
+/* parse jason */
+static HTAB *get_json_as_hash(char *json, int len, const char *funcname);
+static void  hash_object_field_start(void *state, char *fname, bool isnull);
+static void  hash_object_field_end(void *state, char *fname, bool isnull);
+static void  hash_array_start(void *state);
+static void  hash_scalar(void *state, char *token, JsonTokenType tokentype);
+
+/* encode json */
+
+typedef enum        /* type categories for datum_to_json */
+{ JSONTYPE_NULL,    /* null, so we didn't bother to identify */
+  JSONTYPE_BOOL,    /* boolean (built-in types only) */
+  JSONTYPE_NUMERIC, /* numeric (ditto) */
+  JSONTYPE_DATE,    /* we use special formatting for datetimes */
+  JSONTYPE_TIMESTAMP,
+  JSONTYPE_TIMESTAMPTZ,
+  JSONTYPE_JSON,      /* JSON itself (and JSONB) */
+  JSONTYPE_ARRAY,     /* array */
+  JSONTYPE_COMPOSITE, /* composite */
+  JSONTYPE_CAST,      /* something with an explicit cast to JSON */
+  JSONTYPE_OTHER      /* all else */
+} JsonTypeCategory;
+
+static void json_categorize_type(Oid typoid, JsonTypeCategory *tcategory, Oid *outfuncoid);
+static void array_dim_to_json(StringInfo       result,
+                              int              dim,
+                              int              ndims,
+                              int *            dims,
+                              Datum *          vals,
+                              bool *           nulls,
+                              int *            valcount,
+                              JsonTypeCategory tcategory,
+                              Oid              outfuncoid,
+                              bool             use_line_feeds);
+
+static void array_to_json_internal(Datum array, StringInfo result, bool use_line_feeds);
+static void datum_to_json(Datum            val,
+                          bool             is_null,
+                          StringInfo       result,
+                          JsonTypeCategory tcategory,
+                          Oid              outfuncoid,
+                          bool             key_scalar);
+static void add_json(Datum val, bool is_null, StringInfo result, Oid val_type, bool key_scalar);
+static void composite_to_json(Datum composite, StringInfo result, bool use_line_feeds);
 /*
  * Parse the char into separate attributes (fields)
  * Returns number of fields or -1 in case of unterminated quoted string
@@ -7,6 +58,8 @@
 int
 KafkaReadAttributesCSV(char *msg, int msg_len, KafkaFdwExecutionState *festate, bool *unterminated_error)
 {
+    DEBUGLOG("%s", __func__);
+
     char  delimc  = festate->parse_options.delim[0];
     char  quotec  = festate->parse_options.quote[0];
     char  escapec = festate->parse_options.escape[0];
@@ -16,7 +69,6 @@ KafkaReadAttributesCSV(char *msg, int msg_len, KafkaFdwExecutionState *festate, 
     char *line_end_ptr;
 
     *unterminated_error = false;
-
     resetStringInfo(&festate->attribute_buf);
     /*
      * The de-escaped attributes will certainly not be longer than the input
@@ -172,25 +224,38 @@ KafkaReadAttributesCSV(char *msg, int msg_len, KafkaFdwExecutionState *festate, 
  */
 
 void
-KafkaWriteAttributesCSV(KafkaFdwModifyState *festate, const char **values, int num_values)
+KafkaWriteAttributesCSV(KafkaFdwModifyState *festate, TupleTableSlot *slot)
 {
     DEBUGLOG("%s", __func__);
-    int  attnum;
-    char delimc  = festate->parse_options.delim[0];
-    char quotec  = festate->parse_options.quote[0];
-    char escapec = festate->parse_options.escape[0];
 
-    for (attnum = 1; attnum <= num_values; attnum++)
+    ListCell *lc;
+
+    char  delimc         = festate->parse_options.delim[0];
+    char  quotec         = festate->parse_options.quote[0];
+    char  escapec        = festate->parse_options.escape[0];
+    char *null_print     = festate->parse_options.null_print;
+    int   null_print_len = festate->parse_options.null_print_len;
+    int   pindex         = 0;
+
+    foreach (lc, festate->attnumlist)
     {
-
+        int         attnum = lfirst_int(lc);
+        bool        isnull;
         const char *ptr, *start;
         char        c;
         bool        use_quote = false;
-        const char *val       = *values;
-        const char *tptr      = val;
-
-        if (val)
+        const char *val;
+        const char *tptr;
+        Datum       value = slot_getattr(slot, attnum, &isnull);
+        if (isnull)
         {
+            if (null_print)
+                appendBinaryStringInfo(&festate->attribute_buf, null_print, null_print_len);
+        }
+        else
+        {
+            val  = OutputFunctionCall(&festate->out_functions[pindex], value);
+            tptr = val;
             /*
              * Make a preliminary pass to discover if it needs quoting
              */
@@ -229,8 +294,687 @@ KafkaWriteAttributesCSV(KafkaFdwModifyState *festate, const char **values, int n
                 appendBinaryStringInfo(&festate->attribute_buf, ptr, strlen(ptr));
             }
         }
-
+        pindex++;
         appendStringInfoCharMacro(&festate->attribute_buf, delimc);
-        values++;
     }
 }
+
+/* state for get_json_as_hash */
+typedef struct JhashState
+{
+    JsonLexContext *lex;
+    const char *    function_name;
+    HTAB *          hash;
+    char *          saved_scalar;
+    char *          save_json_start;
+} JHashState;
+
+/* hashtable element */
+typedef struct JsonHashEntry
+{
+    char  fname[NAMEDATALEN]; /* hash key (MUST BE FIRST) */
+    char *val;
+    char *json;
+    bool  isnull;
+} JsonHashEntry;
+
+/*
+ * get_json_as_hash
+ *
+ * decompose a json object into a hash table.
+ */
+static HTAB *
+get_json_as_hash(char *json, int len, const char *funcname)
+{
+    HASHCTL         ctl;
+    HTAB *          tab;
+    JHashState *    state;
+    JsonLexContext *lex = makeJsonLexContextCstringLen(json, len, true);
+    JsonSemAction * sem;
+
+    memset(&ctl, 0, sizeof(ctl));
+    ctl.keysize   = NAMEDATALEN;
+    ctl.entrysize = sizeof(JsonHashEntry);
+    ctl.hcxt      = CurrentMemoryContext;
+    tab           = hash_create("json object hashtable", 100, &ctl, HASH_ELEM | HASH_CONTEXT);
+
+    state = palloc0(sizeof(JHashState));
+    sem   = palloc0(sizeof(JsonSemAction));
+
+    state->function_name = funcname;
+    state->hash          = tab;
+    state->lex           = lex;
+
+    sem->semstate           = (void *) state;
+    sem->array_start        = hash_array_start;
+    sem->scalar             = hash_scalar;
+    sem->object_field_start = hash_object_field_start;
+    sem->object_field_end   = hash_object_field_end;
+
+    pg_parse_json(lex, sem);
+
+    return tab;
+}
+
+static void
+hash_object_field_start(void *state, char *fname, bool isnull)
+{
+    JHashState *_state = (JHashState *) state;
+
+    if (_state->lex->lex_level > 1)
+        return;
+
+    if (_state->lex->token_type == JSON_TOKEN_ARRAY_START || _state->lex->token_type == JSON_TOKEN_OBJECT_START)
+    {
+        /* remember start position of the whole text of the subobject */
+        _state->save_json_start = _state->lex->token_start;
+    }
+    else
+    {
+        /* must be a scalar */
+        _state->save_json_start = NULL;
+    }
+}
+
+static void
+hash_object_field_end(void *state, char *fname, bool isnull)
+{
+    JHashState *   _state = (JHashState *) state;
+    JsonHashEntry *hashentry;
+    bool           found;
+
+    /*
+     * Ignore nested fields.
+     */
+    if (_state->lex->lex_level > 1)
+        return;
+
+    /*
+     * Ignore field names >= NAMEDATALEN - they can't match a record field.
+     * (Note: without this test, the hash code would truncate the string at
+     * NAMEDATALEN-1, and could then match against a similarly-truncated
+     * record field name.  That would be a reasonable behavior, but this code
+     * has previously insisted on exact equality, so we keep this behavior.)
+     */
+    if (strlen(fname) >= NAMEDATALEN)
+        return;
+
+    hashentry = hash_search(_state->hash, fname, HASH_ENTER, &found);
+
+    /*
+     * found being true indicates a duplicate. We don't do anything about
+     * that, a later field with the same name overrides the earlier field.
+     */
+
+    hashentry->isnull = isnull;
+    if (_state->save_json_start != NULL)
+    {
+        int   len = _state->lex->prev_token_terminator - _state->save_json_start;
+        char *val = palloc((len + 1) * sizeof(char));
+
+        memcpy(val, _state->save_json_start, len);
+        val[len]       = '\0';
+        hashentry->val = val;
+    }
+    else
+    {
+        /* must have had a scalar instead */
+        hashentry->val = _state->saved_scalar;
+    }
+}
+
+static void
+hash_array_start(void *state)
+{
+    JHashState *_state = (JHashState *) state;
+
+    if (_state->lex->lex_level == 0)
+        ereport(
+          ERROR,
+          (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("cannot call %s on an array", _state->function_name)));
+}
+
+static void
+hash_scalar(void *state, char *token, JsonTokenType tokentype)
+{
+    JHashState *_state = (JHashState *) state;
+
+    if (_state->lex->lex_level == 0)
+        ereport(
+          ERROR,
+          (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("cannot call %s on a scalar", _state->function_name)));
+
+    if (_state->lex->lex_level == 1)
+        _state->saved_scalar = token;
+}
+
+int
+KafkaReadAttributesJson(char *msg, int msg_len, KafkaFdwExecutionState *festate, bool *error)
+{
+    ListCell *    cur;
+    HTAB *        json_hash;
+    int           fieldno     = 0;
+    int           num_ent     = 0;
+    bool          ignore_junk = festate->kafka_options.ignore_junk;
+    MemoryContext ccxt        = CurrentMemoryContext;
+
+    *error = false;
+    /* much like populate_record_worker but with error cathing if needed */
+    if (ignore_junk)
+    {
+        PG_TRY();
+        {
+            json_hash = get_json_as_hash(msg, msg_len, "KafkaReadAttributesJson");
+        }
+        PG_CATCH();
+        {
+            *error = true;
+            MemoryContextSwitchTo(ccxt);
+
+            /* accumulate errors if needed */
+            if (festate->kafka_options.junk_error_attnum != -1)
+            {
+                ErrorData *errdata = CopyErrorData();
+
+                if (festate->junk_buf.len > 0)
+                    appendStringInfoCharMacro(&festate->junk_buf, '\n');
+
+                appendStringInfoString(&festate->junk_buf, errdata->message);
+            }
+            FlushErrorState();
+            return 0;
+        }
+        PG_END_TRY();
+    }
+    else
+        json_hash = get_json_as_hash(msg, msg_len, "KafkaReadAttributesJson");
+
+    num_ent = hash_get_num_entries(json_hash);
+    if (num_ent == 0)
+    {
+        return 0;
+    }
+
+    foreach (cur, festate->attnumlist)
+    {
+        int            attnum    = lfirst_int(cur);
+        int            m         = attnum - 1;
+        JsonHashEntry *hashentry = NULL;
+        /* Make sure there is enough space for the next value */
+        if (fieldno >= festate->max_fields)
+        {
+            festate->max_fields *= 2;
+            festate->raw_fields = repalloc(festate->raw_fields, festate->max_fields * sizeof(char *));
+        }
+
+        if (parsable_attnum(attnum, festate->kafka_options))
+        {
+            hashentry = hash_search(json_hash, festate->attnames[m], HASH_FIND, NULL);
+            if (hashentry == NULL || hashentry->isnull)
+                festate->raw_fields[fieldno] = NULL;
+            else
+                festate->raw_fields[fieldno] = hashentry->val;
+
+            fieldno++;
+        }
+    }
+    /* report back total number of found fields to match against strict mode */
+    return num_ent;
+}
+
+/*
+ * Determine how we want to print values of a given type in datum_to_json.
+ *
+ * Given the datatype OID, return its JsonTypeCategory, as well as the type's
+ * output function OID.  If the returned category is JSONTYPE_CAST, we
+ * return the OID of the type->JSON cast function instead.
+ */
+static void
+json_categorize_type(Oid typoid, JsonTypeCategory *tcategory, Oid *outfuncoid)
+{
+    bool typisvarlena;
+
+    /* Look through any domain */
+    typoid = getBaseType(typoid);
+
+    *outfuncoid = InvalidOid;
+
+    /*
+     * We need to get the output function for everything except date and
+     * timestamp types, array and composite types, booleans, and non-builtin
+     * types where there's a cast to json.
+     */
+
+    switch (typoid)
+    {
+        case BOOLOID: *tcategory = JSONTYPE_BOOL; break;
+
+        case INT2OID:
+        case INT4OID:
+        case INT8OID:
+        case FLOAT4OID:
+        case FLOAT8OID:
+        case NUMERICOID:
+            getTypeOutputInfo(typoid, outfuncoid, &typisvarlena);
+            *tcategory = JSONTYPE_NUMERIC;
+            break;
+
+        case DATEOID: *tcategory = JSONTYPE_DATE; break;
+
+        case TIMESTAMPOID: *tcategory = JSONTYPE_TIMESTAMP; break;
+
+        case TIMESTAMPTZOID: *tcategory = JSONTYPE_TIMESTAMPTZ; break;
+
+        case JSONOID:
+        case JSONBOID:
+            getTypeOutputInfo(typoid, outfuncoid, &typisvarlena);
+            *tcategory = JSONTYPE_JSON;
+            break;
+
+        default:
+            /* Check for arrays and composites */
+            if (OidIsValid(get_element_type(typoid)))
+                *tcategory = JSONTYPE_ARRAY;
+            else if (type_is_rowtype(typoid))
+                *tcategory = JSONTYPE_COMPOSITE;
+            else
+            {
+                /* It's probably the general case ... */
+                *tcategory = JSONTYPE_OTHER;
+                /* but let's look for a cast to json, if it's not built-in */
+                if (typoid >= FirstNormalObjectId)
+                {
+                    Oid              castfunc;
+                    CoercionPathType ctype;
+
+                    ctype = find_coercion_pathway(JSONOID, typoid, COERCION_EXPLICIT, &castfunc);
+                    if (ctype == COERCION_PATH_FUNC && OidIsValid(castfunc))
+                    {
+                        *tcategory  = JSONTYPE_CAST;
+                        *outfuncoid = castfunc;
+                    }
+                    else
+                    {
+                        /* non builtin type with no cast */
+                        getTypeOutputInfo(typoid, outfuncoid, &typisvarlena);
+                    }
+                }
+                else
+                {
+                    /* any other builtin type */
+                    getTypeOutputInfo(typoid, outfuncoid, &typisvarlena);
+                }
+            }
+            break;
+    }
+}
+
+/*
+ * Process a single dimension of an array.
+ * If it's the innermost dimension, output the values, otherwise call
+ * ourselves recursively to process the next dimension.
+ */
+static void
+array_dim_to_json(StringInfo       result,
+                  int              dim,
+                  int              ndims,
+                  int *            dims,
+                  Datum *          vals,
+                  bool *           nulls,
+                  int *            valcount,
+                  JsonTypeCategory tcategory,
+                  Oid              outfuncoid,
+                  bool             use_line_feeds)
+{
+    int         i;
+    const char *sep;
+
+    Assert(dim < ndims);
+
+    sep = use_line_feeds ? ",\n " : ",";
+
+    appendStringInfoChar(result, '[');
+
+    for (i = 1; i <= dims[dim]; i++)
+    {
+        if (i > 1)
+            appendStringInfoString(result, sep);
+
+        if (dim + 1 == ndims)
+        {
+            datum_to_json(vals[*valcount], nulls[*valcount], result, tcategory, outfuncoid, false);
+            (*valcount)++;
+        }
+        else
+        {
+            /*
+             * Do we want line feeds on inner dimensions of arrays? For now
+             * we'll say no.
+             */
+            array_dim_to_json(result, dim + 1, ndims, dims, vals, nulls, valcount, tcategory, outfuncoid, false);
+        }
+    }
+
+    appendStringInfoChar(result, ']');
+}
+
+/*
+ * Turn an array into JSON.
+ */
+static void
+array_to_json_internal(Datum array, StringInfo result, bool use_line_feeds)
+{
+    ArrayType *      v            = DatumGetArrayTypeP(array);
+    Oid              element_type = ARR_ELEMTYPE(v);
+    int *            dim;
+    int              ndim;
+    int              nitems;
+    int              count = 0;
+    Datum *          elements;
+    bool *           nulls;
+    int16            typlen;
+    bool             typbyval;
+    char             typalign;
+    JsonTypeCategory tcategory;
+    Oid              outfuncoid;
+
+    ndim   = ARR_NDIM(v);
+    dim    = ARR_DIMS(v);
+    nitems = ArrayGetNItems(ndim, dim);
+
+    if (nitems <= 0)
+    {
+        appendStringInfoString(result, "[]");
+        return;
+    }
+
+    get_typlenbyvalalign(element_type, &typlen, &typbyval, &typalign);
+
+    json_categorize_type(element_type, &tcategory, &outfuncoid);
+
+    deconstruct_array(v, element_type, typlen, typbyval, typalign, &elements, &nulls, &nitems);
+
+    array_dim_to_json(result, 0, ndim, dim, elements, nulls, &count, tcategory, outfuncoid, use_line_feeds);
+
+    pfree(elements);
+    pfree(nulls);
+}
+
+/*
+ * Turn a Datum into JSON text, appending the string to "result".
+ *
+ * tcategory and outfuncoid are from a previous call to json_categorize_type,
+ * except that if is_null is true then they can be invalid.
+ *
+ * If key_scalar is true, the value is being printed as a key, so insist
+ * it's of an acceptable type, and force it to be quoted.
+ */
+static void
+datum_to_json(Datum val, bool is_null, StringInfo result, JsonTypeCategory tcategory, Oid outfuncoid, bool key_scalar)
+{
+    char *outputstr;
+    text *jsontext;
+
+    check_stack_depth();
+
+    /* callers are expected to ensure that null keys are not passed in */
+    Assert(!(key_scalar && is_null));
+
+    if (is_null)
+    {
+        appendStringInfoString(result, "null");
+        return;
+    }
+
+    if (key_scalar && (tcategory == JSONTYPE_ARRAY || tcategory == JSONTYPE_COMPOSITE || tcategory == JSONTYPE_JSON ||
+                       tcategory == JSONTYPE_CAST))
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("key value must be scalar, not array, composite, or json")));
+
+    switch (tcategory)
+    {
+        case JSONTYPE_ARRAY: array_to_json_internal(val, result, false); break;
+        case JSONTYPE_COMPOSITE: composite_to_json(val, result, false); break;
+        case JSONTYPE_BOOL:
+            outputstr = DatumGetBool(val) ? "true" : "false";
+            if (key_scalar)
+                escape_json(result, outputstr);
+            else
+                appendStringInfoString(result, outputstr);
+            break;
+        case JSONTYPE_NUMERIC:
+            outputstr = OidOutputFunctionCall(outfuncoid, val);
+
+            /*
+             * Don't call escape_json for a non-key if it's a valid JSON
+             * number.
+             */
+            if (!key_scalar && IsValidJsonNumber(outputstr, strlen(outputstr)))
+                appendStringInfoString(result, outputstr);
+            else
+                escape_json(result, outputstr);
+            pfree(outputstr);
+            break;
+        case JSONTYPE_DATE:
+        {
+            DateADT      date;
+            struct pg_tm tm;
+            char         buf[MAXDATELEN + 1];
+
+            date = DatumGetDateADT(val);
+            /* Same as date_out(), but forcing DateStyle */
+            if (DATE_NOT_FINITE(date))
+                EncodeSpecialDate(date, buf);
+            else
+            {
+                j2date(date + POSTGRES_EPOCH_JDATE, &(tm.tm_year), &(tm.tm_mon), &(tm.tm_mday));
+                EncodeDateOnly(&tm, USE_XSD_DATES, buf);
+            }
+            appendStringInfo(result, "\"%s\"", buf);
+        }
+        break;
+        case JSONTYPE_TIMESTAMP:
+        {
+            Timestamp    timestamp;
+            struct pg_tm tm;
+            fsec_t       fsec;
+            char         buf[MAXDATELEN + 1];
+
+            timestamp = DatumGetTimestamp(val);
+            /* Same as timestamp_out(), but forcing DateStyle */
+            if (TIMESTAMP_NOT_FINITE(timestamp))
+                EncodeSpecialTimestamp(timestamp, buf);
+            else if (timestamp2tm(timestamp, NULL, &tm, &fsec, NULL, NULL) == 0)
+                EncodeDateTime(&tm, fsec, false, 0, NULL, USE_XSD_DATES, buf);
+            else
+                ereport(ERROR, (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE), errmsg("timestamp out of range")));
+            appendStringInfo(result, "\"%s\"", buf);
+        }
+        break;
+        case JSONTYPE_TIMESTAMPTZ:
+        {
+            TimestampTz  timestamp;
+            struct pg_tm tm;
+            int          tz;
+            fsec_t       fsec;
+            const char * tzn = NULL;
+            char         buf[MAXDATELEN + 1];
+
+            timestamp = DatumGetTimestampTz(val);
+            /* Same as timestamptz_out(), but forcing DateStyle */
+            if (TIMESTAMP_NOT_FINITE(timestamp))
+                EncodeSpecialTimestamp(timestamp, buf);
+            else if (timestamp2tm(timestamp, &tz, &tm, &fsec, &tzn, NULL) == 0)
+                EncodeDateTime(&tm, fsec, true, tz, tzn, USE_XSD_DATES, buf);
+            else
+                ereport(ERROR, (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE), errmsg("timestamp out of range")));
+            appendStringInfo(result, "\"%s\"", buf);
+        }
+        break;
+        case JSONTYPE_JSON:
+            /* JSON and JSONB output will already be escaped */
+            outputstr = OidOutputFunctionCall(outfuncoid, val);
+            appendStringInfoString(result, outputstr);
+            pfree(outputstr);
+            break;
+        case JSONTYPE_CAST:
+            /* outfuncoid refers to a cast function, not an output function */
+            jsontext  = DatumGetTextP(OidFunctionCall1(outfuncoid, val));
+            outputstr = text_to_cstring(jsontext);
+            appendStringInfoString(result, outputstr);
+            pfree(outputstr);
+            pfree(jsontext);
+            break;
+        default:
+            outputstr = OidOutputFunctionCall(outfuncoid, val);
+            escape_json(result, outputstr);
+            pfree(outputstr);
+            break;
+    }
+}
+
+/*
+ * Turn a composite / record into JSON.
+ */
+static void
+composite_to_json(Datum composite, StringInfo result, bool use_line_feeds)
+{
+    HeapTupleHeader td;
+    Oid             tupType;
+    int32           tupTypmod;
+    TupleDesc       tupdesc;
+    HeapTupleData   tmptup, *tuple;
+    int             i;
+    bool            needsep = false;
+    const char *    sep;
+
+    sep = use_line_feeds ? ",\n " : ",";
+
+    td = DatumGetHeapTupleHeader(composite);
+
+    /* Extract rowtype info and find a tupdesc */
+    tupType   = HeapTupleHeaderGetTypeId(td);
+    tupTypmod = HeapTupleHeaderGetTypMod(td);
+    tupdesc   = lookup_rowtype_tupdesc(tupType, tupTypmod);
+
+    /* Build a temporary HeapTuple control structure */
+    tmptup.t_len  = HeapTupleHeaderGetDatumLength(td);
+    tmptup.t_data = td;
+    tuple         = &tmptup;
+
+    appendStringInfoChar(result, '{');
+
+    for (i = 0; i < tupdesc->natts; i++)
+    {
+        Datum            val;
+        bool             isnull;
+        char *           attname;
+        JsonTypeCategory tcategory;
+        Oid              outfuncoid;
+
+        if (tupdesc->attrs[i]->attisdropped)
+            continue;
+
+        if (needsep)
+            appendStringInfoString(result, sep);
+        needsep = true;
+
+        attname = NameStr(tupdesc->attrs[i]->attname);
+        escape_json(result, attname);
+        appendStringInfoChar(result, ':');
+
+        val = heap_getattr(tuple, i + 1, tupdesc, &isnull);
+
+        if (isnull)
+        {
+            tcategory  = JSONTYPE_NULL;
+            outfuncoid = InvalidOid;
+        }
+        else
+            json_categorize_type(tupdesc->attrs[i]->atttypid, &tcategory, &outfuncoid);
+
+        datum_to_json(val, isnull, result, tcategory, outfuncoid, false);
+    }
+
+    appendStringInfoChar(result, '}');
+    ReleaseTupleDesc(tupdesc);
+}
+
+/*
+ * Append JSON text for "val" to "result".
+ *
+ * This is just a thin wrapper around datum_to_json.  If the same type will be
+ * printed many times, avoid using this; better to do the json_categorize_type
+ * lookups only once.
+ */
+static void
+add_json(Datum val, bool is_null, StringInfo result, Oid val_type, bool key_scalar)
+{
+    JsonTypeCategory tcategory;
+    Oid              outfuncoid;
+
+    if (val_type == InvalidOid)
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("could not determine input data type")));
+
+    if (is_null)
+    {
+        tcategory  = JSONTYPE_NULL;
+        outfuncoid = InvalidOid;
+    }
+    else
+        json_categorize_type(val_type, &tcategory, &outfuncoid);
+
+    datum_to_json(val, is_null, result, tcategory, outfuncoid, key_scalar);
+}
+
+void
+KafkaWriteAttributesJson(KafkaFdwModifyState *festate, TupleTableSlot *slot)
+{
+    DEBUGLOG("%s", __func__);
+
+    /* much like json_build_object */
+    ListCell *  lc;
+    int         pindex   = 0;
+    const char *sep      = ", ";
+    char **     attnames = festate->attnames;
+    StringInfo  result   = &festate->attribute_buf;
+
+    appendStringInfoCharMacro(result, '{');
+    foreach (lc, festate->attnumlist)
+    {
+        DEBUGLOG("attname %s", *attnames);
+        DEBUGLOG("typeoid %u", *festate->typioparams);
+        bool  isnull;
+        int   attnum = lfirst_int(lc);
+        Datum value  = slot_getattr(slot, attnum, &isnull);
+        if (pindex > 0)
+            appendStringInfoString(result, sep);
+
+        appendStringInfoCharMacro(result, '"');
+        appendStringInfoString(result, attnames[pindex]);
+        appendStringInfoCharMacro(result, '"');
+
+        appendStringInfoString(result, " : ");
+
+        add_json(value, isnull, result, festate->typioparams[pindex], false);
+
+        pindex++;
+    }
+
+    appendStringInfoCharMacro(result, '}');
+}
+/*
+
+
+
+
+
+
+
+
+
+
+
+
+*/

--- a/test/expected/error_test.out
+++ b/test/expected/error_test.out
@@ -14,8 +14,8 @@ CREATE FOREIGN TABLE kafka_err_test (
     some_time timestamp
 )
 SERVER kafka_server2 OPTIONS 
-    (format 'json', batch_size '30', buffer_delay '100');
-ERROR:  COPY format "json" not recognized
+    (format 'foo', batch_size '30', buffer_delay '100');
+ERROR:  format "foo" not recognized
 ROLLBACK;
 /*
 -- no partition and offset colum should error out

--- a/test/expected/json_producer_test.out
+++ b/test/expected/json_producer_test.out
@@ -1,0 +1,156 @@
+CREATE FOREIGN TABLE kafka_test_prod_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_prod_json', batch_size '3000', buffer_delay '100');
+INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date)
+    VALUES
+    (1, 1,'foo bar 1','2017-01-01'),
+    (1, 2,'foo text 2','2017-01-02'),
+    (1, 3,'foo text 3','2017-01-03'),
+    (1, 4,'foo text 4','2017-01-04'),
+    (1, 5,'foo text 5','2017-01-05'),
+    (1, 6,'foo text 6','2017-01-06'),
+    (1, 7,'foo bar 7','2017-01-07'),
+    (1, 8,'foo text 8','2017-01-08'),
+    (1, 9,'foo text 9','2017-01-09'),
+    (1, 10,'foo text 10','2017-01-10')
+RETURNING *;
+ part | offs | some_int |  some_text  | some_date  | some_time 
+------+------+----------+-------------+------------+-----------
+    1 |      |        1 | foo bar 1   | 01-01-2017 | 
+    1 |      |        2 | foo text 2  | 01-02-2017 | 
+    1 |      |        3 | foo text 3  | 01-03-2017 | 
+    1 |      |        4 | foo text 4  | 01-04-2017 | 
+    1 |      |        5 | foo text 5  | 01-05-2017 | 
+    1 |      |        6 | foo text 6  | 01-06-2017 | 
+    1 |      |        7 | foo bar 7   | 01-07-2017 | 
+    1 |      |        8 | foo text 8  | 01-08-2017 | 
+    1 |      |        9 | foo text 9  | 01-09-2017 | 
+    1 |      |       10 | foo text 10 | 01-10-2017 | 
+(10 rows)
+
+-- run some memload
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM kafka_test_prod_json WHERE offs >= 0 and part=1;
+ part | offs | some_int |  some_text  | some_date  | some_time 
+------+------+----------+-------------+------------+-----------
+    1 |    0 |        1 | foo bar 1   | 01-01-2017 | 
+    1 |    1 |        2 | foo text 2  | 01-02-2017 | 
+    1 |    2 |        3 | foo text 3  | 01-03-2017 | 
+    1 |    3 |        4 | foo text 4  | 01-04-2017 | 
+    1 |    4 |        5 | foo text 5  | 01-05-2017 | 
+    1 |    5 |        6 | foo text 6  | 01-06-2017 | 
+    1 |    6 |        7 | foo bar 7   | 01-07-2017 | 
+    1 |    7 |        8 | foo text 8  | 01-08-2017 | 
+    1 |    8 |        9 | foo text 9  | 01-09-2017 | 
+    1 |    9 |       10 | foo text 10 | 01-10-2017 | 
+(10 rows)
+
+INSERT INTO kafka_test_prod_json(some_int, some_text, some_date, some_time)
+SELECT i,
+    'It''s some text, that is for number '||i,
+    ('2015-01-01'::date + (i || ' minutes')::interval)::date,
+    ('2015-01-01'::date + (i || ' minutes')::interval)::timestamp
+FROM generate_series(1,1e4::int, 10) i ORDER BY i;
+--- check total was inserted
+SELECT SUM(count) FROM(
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=0
+UNION ALL
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=1
+UNION ALL
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=2
+UNION ALL
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=3
+)t;
+ sum  
+------
+ 1010
+(1 row)
+
+--- check auto distribution makes sense
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=2;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=3;
+ ?column? 
+----------
+ t
+(1 row)
+
+--- check data is readable
+SELECT some_int, some_text, some_date FROM(
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=0 AND some_int = 231 LIMIT 1)
+UNION ALL
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=1 AND some_int = 231 LIMIT 1)
+UNION ALL
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=2 AND some_int = 231 LIMIT 1)
+UNION ALL
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=3 AND some_int = 231 LIMIT 1)
+)t;
+ some_int |               some_text                | some_date  
+----------+----------------------------------------+------------
+      231 | It's some text, that is for number 231 | 01-01-2015
+(1 row)
+

--- a/test/expected/json_test.out
+++ b/test/expected/json_test.out
@@ -1,131 +1,15 @@
 -- standard setup
-CREATE FOREIGN TABLE kafka_test_part (
+CREATE FOREIGN TABLE kafka_test_json (
     part int OPTIONS (partition 'true'),
     offs bigint OPTIONS (offset 'true'),
-    some_int int,
-    some_text text,
-    some_date date,
-    some_time timestamp
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
 )
 SERVER kafka_server OPTIONS
-    (format 'csv', topic 'contrib_regress4', batch_size '30', buffer_delay '100');
-CREATE FOREIGN TABLE kafka_test_single_part (
-    part int OPTIONS (partition 'true'),
-    offs bigint OPTIONS (offset 'true'),
-    some_int int,
-    some_text text,
-    some_date date,
-    some_time timestamp
-)
-SERVER kafka_server OPTIONS
-    (format 'csv', topic 'contrib_regress', batch_size '30', buffer_delay '100');
--- check that we parse the queries right or error out if needed
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE offs = 1 AND part = 0;
-              QUERY PLAN               
----------------------------------------
- Foreign Scan on kafka_test_part
-   Filter: ((offs = 1) AND (part = 0))
-   Kafka topic: contrib_regress4
-   scanning: PARTITION = 0 OFFSET 1 
-(4 rows)
-
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE part=1 AND some_int = 3 AND offs > 4 AND offs > 10 AND offs < 100;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Foreign Scan on kafka_test_part
-   Filter: ((offs > 4) AND (offs > 10) AND (offs < 100) AND (part = 1) AND (some_int = 3))
-   Kafka topic: contrib_regress4
-   scanning: PARTITION = 1 OFFSET 11 
-(4 rows)
-
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE (part,offs)=(1,1) OR (part,offs)=(2,1);
-ERROR:  scanning of multiple partitions not allowed
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE (part,offs) IN((1,1),(2,2)) ;
-ERROR:  scanning of multiple partitions not allowed
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE (part,offs) IN((1,1),(1,2)) ;
-ERROR:  scanning of multiple offsets not allowed
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE some_int = 5 ;
-ERROR:  offset and partition must be set in WHERE clause
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE offs > 5 AND part = 1 ;
-              QUERY PLAN               
----------------------------------------
- Foreign Scan on kafka_test_part
-   Filter: ((offs > 5) AND (part = 1))
-   Kafka topic: contrib_regress4
-   scanning: PARTITION = 1 OFFSET 6 
-(4 rows)
-
-EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE  5 < offs AND 1 = part ;
-              QUERY PLAN               
----------------------------------------
- Foreign Scan on kafka_test_part
-   Filter: ((5 < offs) AND (1 = part))
-   Kafka topic: contrib_regress4
-   scanning: PARTITION = 1 OFFSET 6 
-(4 rows)
-
--- run some memload
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
-select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
- count 
--------
-     1
-(1 row)
-
--- check that we really have messages
-SELECT SUM(count) FROM (
-SELECT COUNT(*) FROM kafka_test_part WHERE part = 0 AND offs >= 0
-UNION ALL
-SELECT COUNT(*) FROM kafka_test_part WHERE part = 1 AND offs >= 0
-UNION ALL
-SELECT COUNT(*) FROM kafka_test_part WHERE part = 2 AND offs >= 0
-UNION ALL
-SELECT COUNT(*) FROM kafka_test_part WHERE part = 3 AND offs >= 0
-UNION ALL
-SELECT COUNT(*) FROM kafka_test_part WHERE part = 4 AND offs >= 0
-)t;
-  sum   
---------
- 100000
-(1 row)
-
--- see that we can properly parse messages
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 0 LIMIT 30;
+    (format 'json', topic 'contrib_regress_json', batch_size '30', buffer_delay '100');
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 0 LIMIT 30;
  part | offs | some_int |               some_text                | some_date  |        some_time         
 ------+------+----------+----------------------------------------+------------+--------------------------
     0 |    1 |       11 | It's some text, that is for number 11  | 01-01-2015 | Thu Jan 01 00:00:11 2015
@@ -160,7 +44,7 @@ SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 0 LIMIT 30;
     0 |   30 |      301 | It's some text, that is for number 301 | 01-01-2015 | Thu Jan 01 00:05:01 2015
 (30 rows)
 
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 10 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 10 LIMIT 30;
  part | offs | some_int |               some_text                | some_date  |        some_time         
 ------+------+----------+----------------------------------------+------------+--------------------------
     0 |   11 |      111 | It's some text, that is for number 111 | 01-01-2015 | Thu Jan 01 00:01:51 2015
@@ -195,7 +79,7 @@ SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 10 LIMIT 30;
     0 |   40 |      401 | It's some text, that is for number 401 | 01-01-2015 | Thu Jan 01 00:06:41 2015
 (30 rows)
 
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 100 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 100 LIMIT 30;
  part | offs | some_int |                some_text                | some_date  |        some_time         
 ------+------+----------+-----------------------------------------+------------+--------------------------
     0 |  101 |     1011 | It's some text, that is for number 1011 | 01-01-2015 | Thu Jan 01 00:16:51 2015
@@ -230,7 +114,7 @@ SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 100 LIMIT 30;
     0 |  130 |     1301 | It's some text, that is for number 1301 | 01-01-2015 | Thu Jan 01 00:21:41 2015
 (30 rows)
 
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 1000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 1000 LIMIT 30;
  part | offs | some_int |                some_text                 | some_date  |        some_time         
 ------+------+----------+------------------------------------------+------------+--------------------------
     0 | 1001 |    10011 | It's some text, that is for number 10011 | 01-01-2015 | Thu Jan 01 02:46:51 2015
@@ -265,7 +149,7 @@ SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 1000 LIMIT 30;
     0 | 1030 |    10301 | It's some text, that is for number 10301 | 01-01-2015 | Thu Jan 01 02:51:41 2015
 (30 rows)
 
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 10000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 10000 LIMIT 30;
  part | offs  | some_int |                 some_text                 | some_date  |        some_time         
 ------+-------+----------+-------------------------------------------+------------+--------------------------
     0 | 10001 |   100011 | It's some text, that is for number 100011 | 01-02-2015 | Fri Jan 02 03:46:51 2015
@@ -300,7 +184,7 @@ SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 10000 LIMIT 30;
     0 | 10030 |   100301 | It's some text, that is for number 100301 | 01-02-2015 | Fri Jan 02 03:51:41 2015
 (30 rows)
 
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 90000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 90000 LIMIT 30;
  part | offs  | some_int |                 some_text                 | some_date  |        some_time         
 ------+-------+----------+-------------------------------------------+------------+--------------------------
     0 | 90001 |   900011 | It's some text, that is for number 900011 | 01-11-2015 | Sun Jan 11 10:00:11 2015
@@ -335,7 +219,7 @@ SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 90000 LIMIT 30;
     0 | 90030 |   900301 | It's some text, that is for number 900301 | 01-11-2015 | Sun Jan 11 10:05:01 2015
 (30 rows)
 
-SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 100000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 100000 LIMIT 30;
  part | offs | some_int | some_text | some_date | some_time 
 ------+------+----------+-----------+-----------+-----------
 (0 rows)

--- a/test/expected/junk_test.out
+++ b/test/expected/junk_test.out
@@ -10,9 +10,20 @@ CREATE FOREIGN TABLE kafka_test_junk (
 )
 SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100');
+CREATE FOREIGN TABLE kafka_test_junk_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    int_val int,
+    text_val text,
+    date_val date,
+    time_val timestamp,
+    junk text OPTIONS (junk 'true'),
+    junk_err text OPTIONS (junk_error 'true')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json_junk', batch_size '30', buffer_delay '100');
 \x on
-with kafkadata as ( SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0 )
-SELECT part, offs, some_int, some_text, some_date, some_time, junk, string_to_array(junk_err, E'\n')  FROM kafkadata;
+SELECT part, offs, some_int, some_text, some_date, some_time, junk, string_to_array(junk_err, E'\n')  FROM kafka_test_junk WHERE offs>=0 and part=0 ;
 -[ RECORD 1 ]---+-------------------------------------------------------------------------------------------------------------------------------------------
 part            | 0
 offs            | 0
@@ -112,4 +123,114 @@ some_date       |
 some_time       | 
 junk            | "401,unterminated string,01-01-2015,Thu Jan 01 06:41:00 2015
 string_to_array | {"unterminated CSV quoted field"}
+
+SELECT part, offs, int_val, text_val, date_val, time_val, junk, string_to_array(junk_err, E'\n')  FROM kafka_test_junk_json WHERE offs>=0 and part=0 ;
+-[ RECORD 1 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 0
+int_val         | 999741
+text_val        | correct line
+date_val        | 01-12-2015
+time_val        | Mon Jan 12 13:42:21 2015
+junk            | 
+string_to_array | 
+-[ RECORD 2 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 1
+int_val         | 999751
+text_val        | additional data
+date_val        | 01-12-2015
+time_val        | Mon Jan 12 13:42:31 2015
+junk            | {"int_val" : 999751, "text_val" : "additional data", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:42:31", "more_val": "to much data"}
+string_to_array | {"extra data after last expected column"}
+-[ RECORD 3 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 2
+int_val         | 999761
+text_val        | additional data although null
+date_val        | 01-12-2015
+time_val        | Mon Jan 12 13:42:41 2015
+junk            | {"int_val" : 999761, "text_val" : "additional data although null", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:42:41", "more_val": null}
+string_to_array | {"extra data after last expected column"}
+-[ RECORD 4 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 3
+int_val         | 999781
+text_val        | invalidat date
+date_val        | 
+time_val        | Mon Jan 12 13:42:51 2015
+junk            | {"int_val" : 999781, "text_val" : "invalidat date", "date_val" : "foob", "time_val" : "2015-01-12T13:43:01", "time_val": "2015-01-12T13:42:51"}
+string_to_array | {"invalid input syntax for type date: \"foob\""}
+-[ RECORD 5 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 4
+int_val         | 
+text_val        | 
+date_val        | 
+time_val        | 
+junk            | {"int_val" : 999791, "text_val" : "invalid json (unterminated quote)", "date_val" : "2015-01-12", "time_val : "2015-01-12T13:43:11"}
+string_to_array | {"invalid input syntax for type json"}
+-[ RECORD 6 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 5
+int_val         | 999801
+text_val        | correct line
+date_val        | 01-12-2015
+time_val        | Mon Jan 12 13:43:21 2015
+junk            | 
+string_to_array | 
+-[ RECORD 7 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 6
+int_val         | 
+text_val        | invalid number
+date_val        | 01-12-2015
+time_val        | Mon Jan 12 13:43:31 2015
+junk            | {"int_val" : 9998119999999999, "text_val" : "invalid number", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:43:31"}
+string_to_array | {"value \"9998119999999999\" is out of range for type integer"}
+-[ RECORD 8 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 7
+int_val         | 999821
+text_val        | correct line
+date_val        | 01-12-2015
+time_val        | Mon Jan 12 13:43:41 2015
+junk            | 
+string_to_array | 
+-[ RECORD 9 ]---+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 8
+int_val         | 
+text_val        | invalid number, invalid date and extra data
+date_val        | 
+time_val        | Mon Jan 12 13:43:51 2015
+junk            | {"int_val" : "9998119999999999",  "text_val" : "invalid number, invalid date and extra data", "date_val" : "2015-13-13", "time_val" : "2015-01-12T13:43:51", "foo": "just to much"}
+string_to_array | {"extra data after last expected column","value \"9998119999999999\" is out of range for type integer","date/time field value out of range: \"2015-13-13\""}
+-[ RECORD 10 ]--+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 9
+int_val         | 999841
+text_val        | empty time
+date_val        | 01-12-2015
+time_val        | 
+junk            | {"int_val" : 999841, "text_val" : "empty time" , "date_val" : "2015-01-12", "time_val" : ""}
+string_to_array | {"invalid input syntax for type timestamp: \"\""}
+-[ RECORD 11 ]--+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 10
+int_val         | 999851
+text_val        | correct line null time
+date_val        | 01-12-2015
+time_val        | 
+junk            | 
+string_to_array | 
+-[ RECORD 12 ]--+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+part            | 0
+offs            | 11
+int_val         | 
+text_val        | 
+date_val        | 
+time_val        | 
+junk            | {"int_val" : 999871, "invalid json no time" : "invalid json", "date_val" : "2015-01-12", "time_val" : }
+string_to_array | {"invalid input syntax for type json"}
 

--- a/test/expected/strict_test.out
+++ b/test/expected/strict_test.out
@@ -8,8 +8,42 @@ CREATE FOREIGN TABLE kafka_strict (
 )
 SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', strict 'true');
-SELECT * FROM kafka_strict WHERE offs>=0 and part=0;
+SELECT * FROM kafka_strict WHERE offs=0 and part=0 LIMIT 1;
+ part | offs | some_int |  some_text   | some_date  |        some_time         
+------+------+----------+--------------+------------+--------------------------
+    0 |    0 |       91 | correct line | 01-01-2015 | Thu Jan 01 01:31:00 2015
+(1 row)
+
+SELECT * FROM kafka_strict WHERE offs=1 and part=0 LIMIT 1;
 ERROR:  extra data after last expected column
+SELECT * FROM kafka_strict WHERE offs=2 and part=0 LIMIT 1;
+ERROR:  extra data after last expected column
+SELECT * FROM kafka_strict WHERE offs=3 and part=0 LIMIT 1;
+ part | offs | some_int |              some_text               | some_date  | some_time 
+------+------+----------+--------------------------------------+------------+-----------
+    0 |    3 |      301 | correct line although last line null | 01-01-2015 | 
+(1 row)
+
+SELECT * FROM kafka_strict WHERE offs=4 and part=0 LIMIT 1;
+ERROR:  invalid input syntax for type date: "invalid_date"
+SELECT * FROM kafka_strict WHERE offs=5 and part=0 LIMIT 1;
+ERROR:  unterminated CSV quoted field
+SELECT * FROM kafka_strict WHERE offs=6 and part=0 LIMIT 1;
+ part | offs | some_int |  some_text   | some_date  |        some_time         
+------+------+----------+--------------+------------+--------------------------
+    0 |    6 |      421 | correct line | 01-01-2015 | Thu Jan 01 07:01:00 2015
+(1 row)
+
+SELECT * FROM kafka_strict WHERE offs=8 and part=0 LIMIT 1;
+ part | offs | some_int |  some_text   | some_date  |        some_time         
+------+------+----------+--------------+------------+--------------------------
+    0 |    8 |      521 | correct line | 01-01-2015 | Thu Jan 01 08:41:00 2015
+(1 row)
+
+SELECT * FROM kafka_strict WHERE offs=9 and part=0 LIMIT 1;
+ERROR:  extra data after last expected column
+SELECT * FROM kafka_strict WHERE offs=10 and part=0 LIMIT 1;
+ERROR:  unterminated CSV quoted field
 CREATE FOREIGN TABLE kafka_ignore_junk (
     part int OPTIONS (partition 'true'),
     offs bigint OPTIONS (offset 'true'),
@@ -35,4 +69,79 @@ SELECT * FROM kafka_ignore_junk WHERE offs>=0 and part=0;
     0 |    9 |          | invalid number, invalid date and extra data |            | Thu Jan 01 09:31:00 2015
     0 |   10 |          |                                             |            | 
 (11 rows)
+
+CREATE FOREIGN TABLE kafka_strict_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    text_val text,
+    some_date date OPTIONS (json 'date_val'),
+    time_val timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json_junk', batch_size '30', buffer_delay '100', strict 'true');
+SELECT * FROM kafka_strict_json WHERE offs=0 and part=0 LIMIT 1;
+ part | offs | some_int |   text_val   | some_date  |         time_val         
+------+------+----------+--------------+------------+--------------------------
+    0 |    0 |   999741 | correct line | 01-12-2015 | Mon Jan 12 13:42:21 2015
+(1 row)
+
+SELECT * FROM kafka_strict_json WHERE offs=1 and part=0 LIMIT 1;
+ERROR:  extra data after last expected column
+SELECT * FROM kafka_strict_json WHERE offs=2 and part=0 LIMIT 1;
+ERROR:  extra data after last expected column
+SELECT * FROM kafka_strict_json WHERE offs=3 and part=0 LIMIT 1;
+ERROR:  invalid input syntax for type date: "foob"
+SELECT * FROM kafka_strict_json WHERE offs=4 and part=0 LIMIT 1;
+ERROR:  invalid input syntax for type json
+DETAIL:  Expected ":", but found "2015".
+CONTEXT:  JSON data, line 1: ...e)", "date_val" : "2015-01-12", "time_val : "2015...
+SELECT * FROM kafka_strict_json WHERE offs=5 and part=0 LIMIT 1;
+ part | offs | some_int |   text_val   | some_date  |         time_val         
+------+------+----------+--------------+------------+--------------------------
+    0 |    5 |   999801 | correct line | 01-12-2015 | Mon Jan 12 13:43:21 2015
+(1 row)
+
+SELECT * FROM kafka_strict_json WHERE offs=6 and part=0 LIMIT 1;
+ERROR:  value "9998119999999999" is out of range for type integer
+SELECT * FROM kafka_strict_json WHERE offs=8 and part=0 LIMIT 1;
+ERROR:  extra data after last expected column
+SELECT * FROM kafka_strict_json WHERE offs=9 and part=0 LIMIT 1;
+ERROR:  invalid input syntax for type timestamp: ""
+SELECT * FROM kafka_strict_json WHERE offs=10 and part=0 LIMIT 1;
+ part | offs | some_int |        text_val        | some_date  | time_val 
+------+------+----------+------------------------+------------+----------
+    0 |   10 |   999851 | correct line null time | 01-12-2015 | 
+(1 row)
+
+SELECT * FROM kafka_strict_json WHERE offs=11 and part=0 LIMIT 1;
+ERROR:  invalid input syntax for type json
+DETAIL:  Expected JSON value, but found "}".
+CONTEXT:  JSON data, line 1: ... json", "date_val" : "2015-01-12", "time_val" : }
+CREATE FOREIGN TABLE kafka_ignore_junk_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    text_val text,
+    some_date date OPTIONS (json 'date_val'),
+    time_val timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json_junk', batch_size '30', buffer_delay '100', ignore_junk 'true');
+SELECT * FROM kafka_ignore_junk_json WHERE offs>=0 and part=0;
+ part | offs | some_int |                  text_val                   | some_date  |         time_val         
+------+------+----------+---------------------------------------------+------------+--------------------------
+    0 |    0 |   999741 | correct line                                | 01-12-2015 | Mon Jan 12 13:42:21 2015
+    0 |    1 |   999751 | additional data                             | 01-12-2015 | Mon Jan 12 13:42:31 2015
+    0 |    2 |   999761 | additional data although null               | 01-12-2015 | Mon Jan 12 13:42:41 2015
+    0 |    3 |   999781 | invalidat date                              |            | Mon Jan 12 13:42:51 2015
+    0 |    4 |          |                                             |            | 
+    0 |    5 |   999801 | correct line                                | 01-12-2015 | Mon Jan 12 13:43:21 2015
+    0 |    6 |          | invalid number                              | 01-12-2015 | Mon Jan 12 13:43:31 2015
+    0 |    7 |   999821 | correct line                                | 01-12-2015 | Mon Jan 12 13:43:41 2015
+    0 |    8 |          | invalid number, invalid date and extra data |            | Mon Jan 12 13:43:51 2015
+    0 |    9 |   999841 | empty time                                  | 01-12-2015 | 
+    0 |   10 |   999851 | correct line null time                      | 01-12-2015 | 
+    0 |   11 |          |                                             |            | 
+(12 rows)
 

--- a/test/init_kafka.sh
+++ b/test/init_kafka.sh
@@ -3,31 +3,43 @@
 : ${KAFKA_PRODUCER:="/usr/local/bin/kafka-console-producer"}
 : ${KAFKA_TOPICS:="/usr/local/bin/kafka-topics"}
 
+
+topics=( contrib_regress4 contrib_regress contrib_regress_prod contrib_regress_prod_json contrib_regress_junk contrib_regress_json contrib_regress_json_junk )
+partitions=( 4 1 4 4 1 1 1 )
+
+declare -a toppart
+index=0
+
+for t in "${topics[@]}"; do
+  toppart[$index]="--topic ${t} --partitions ${partitions[${index}]}"
+  ((index++))
+done
+
 topic_part4="contrib_regress4"
 simple_topic="contrib_regress"
 prod_topic="contrib_regress_prod"
+json_prod_topic="contrib_regress_prod_json"
 junk_topic="contrib_regress_junk"
-out_sql="SELECT i, 'It''s some text, that is for number '||i, ('2015-01-01'::date + (i || ' seconds')::interval)::date, ('2015-01-01'::date + (i || ' seconds')::interval)::timestamp FROM generate_series(1,1e6::int, 10) i ORDER BY i"
+json_topic="contrib_regress_json"
+json_junk_topic="contrib_regress_json_junk"
+
+out_sql="SELECT i as int_val, 'It''s some text, that is for number '||i as text_val, ('2015-01-01'::date + (i || ' seconds')::interval)::date as date_val, ('2015-01-01'::date + (i || ' seconds')::interval)::timestamp as time_val FROM generate_series(1,1e6::int, 10) i ORDER BY i"
 kafka_cmd="$KAFKA_PRODUCER --broker-list localhost:9092 --topic"
 
 # delete topic if it might exist
-for t in $simple_topic $topic_part4 $prod_topic $junk_topic; do
-    $KAFKA_TOPICS --zookeeper localhost:2181 --delete --topic ${t}
-done
-sleep 2
+for t in "${topics[@]}"; do $KAFKA_TOPICS --zookeeper localhost:2181 --delete --topic ${t} & done; wait
 
-# create topic with 4 partitions
-$KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${simple_topic} --partitions 1 --replication-factor 1
-$KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${topic_part4} --partitions 4 --replication-factor 1
-$KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${prod_topic} --partitions 4 --replication-factor 1
-$KAFKA_TOPICS --zookeeper localhost:2181 --create --topic ${junk_topic} --partitions 1 --replication-factor 1
+
+# create topics with partitions
+for t in "${toppart[@]}"; do $KAFKA_TOPICS --zookeeper localhost:2181 --create ${t} --replication-factor 1 & done; wait
 
 # write some test data to topicc
-for t in $simple_topic $topic_part4; do
-	psql -c "COPY(${out_sql}) TO STDOUT (FORMAT CSV);" -d postgres -p $PG_PORT -o "| ${kafka_cmd} ${t}" >/dev/null
-done;
+psql -c "COPY(SELECT json_build_object('int_val',int_val, 'text_val',text_val, 'date_val',date_val, 'time_val', time_val ) FROM (${out_sql}) t) TO STDOUT (FORMAT TEXT);" -d postgres -p $PG_PORT -o "| ${kafka_cmd} ${json_topic}" >/dev/null &
 
-$kafka_cmd $junk_topic <<-EOF
+for t in contrib_regress contrib_regress4; do psql -c "COPY(${out_sql}) TO STDOUT (FORMAT CSV);" -d postgres -p $PG_PORT -o "| ${kafka_cmd} ${t}" >/dev/null & done; wait
+
+
+$kafka_cmd contrib_regress_junk <<-EOF
 91,"correct line",01-01-2015,Thu Jan 01 01:31:00 2015
 131,"additional data",01-01-2015,Thu Jan 01 02:11:00 2015,aditional data
 161,"additional data although null",01-01-2015,Thu Jan 01 02:41:00 2015,
@@ -39,4 +51,20 @@ $kafka_cmd $junk_topic <<-EOF
 521,"correct line",01-01-2015,Thu Jan 01 08:41:00 2015
 foo,"invalid number, invalid date and extra data",20-20-2015,Thu Jan 01 09:31:00 2015,extra data
 "401,unterminated string,01-01-2015,Thu Jan 01 06:41:00 2015
+EOF
+
+
+$kafka_cmd contrib_regress_json_junk <<-EOF
+{"int_val" : 999741, "text_val" : "correct line", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:42:21"}
+{"int_val" : 999751, "text_val" : "additional data", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:42:31", "more_val": "to much data"}
+{"int_val" : 999761, "text_val" : "additional data although null", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:42:41", "more_val": null}
+{"int_val" : 999781, "text_val" : "invalidat date", "date_val" : "foob", "time_val" : "2015-01-12T13:43:01", "time_val": "2015-01-12T13:42:51"}
+{"int_val" : 999791, "text_val" : "invalid json (unterminated quote)", "date_val" : "2015-01-12", "time_val : "2015-01-12T13:43:11"}
+{"int_val" : 999801, "text_val" : "correct line", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:43:21"}
+{"int_val" : 9998119999999999, "text_val" : "invalid number", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:43:31"}
+{"int_val" : 999821, "text_val" : "correct line", "date_val" : "2015-01-12", "time_val" : "2015-01-12T13:43:41"}
+{"int_val" : "9998119999999999",  "text_val" : "invalid number, invalid date and extra data", "date_val" : "2015-13-13", "time_val" : "2015-01-12T13:43:51", "foo": "just to much"}
+{"int_val" : 999841, "text_val" : "empty time" , "date_val" : "2015-01-12", "time_val" : ""}
+{"int_val" : 999851, "text_val" : "correct line null time", "date_val" : "2015-01-12", "time_val" : null}
+{"int_val" : 999871, "invalid json no time" : "invalid json", "date_val" : "2015-01-12", "time_val" : }
 EOF

--- a/test/sql/error_test.sql
+++ b/test/sql/error_test.sql
@@ -18,7 +18,7 @@ CREATE FOREIGN TABLE kafka_err_test (
     some_time timestamp
 )
 SERVER kafka_server2 OPTIONS 
-    (format 'json', batch_size '30', buffer_delay '100');
+    (format 'foo', batch_size '30', buffer_delay '100');
 ROLLBACK;
 
 

--- a/test/sql/json_producer_test.sql
+++ b/test/sql/json_producer_test.sql
@@ -1,0 +1,74 @@
+CREATE FOREIGN TABLE kafka_test_prod_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int,
+    some_text text,
+    some_date date,
+    some_time timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_prod_json', batch_size '3000', buffer_delay '100');
+
+INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date)
+    VALUES
+    (1, 1,'foo bar 1','2017-01-01'),
+    (1, 2,'foo text 2','2017-01-02'),
+    (1, 3,'foo text 3','2017-01-03'),
+    (1, 4,'foo text 4','2017-01-04'),
+    (1, 5,'foo text 5','2017-01-05'),
+    (1, 6,'foo text 6','2017-01-06'),
+    (1, 7,'foo bar 7','2017-01-07'),
+    (1, 8,'foo text 8','2017-01-08'),
+    (1, 9,'foo text 9','2017-01-09'),
+    (1, 10,'foo text 10','2017-01-10')
+
+RETURNING *;
+
+-- run some memload
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
+
+
+SELECT * FROM kafka_test_prod_json WHERE offs >= 0 and part=1;
+
+INSERT INTO kafka_test_prod_json(some_int, some_text, some_date, some_time)
+SELECT i,
+    'It''s some text, that is for number '||i,
+    ('2015-01-01'::date + (i || ' minutes')::interval)::date,
+    ('2015-01-01'::date + (i || ' minutes')::interval)::timestamp
+FROM generate_series(1,1e4::int, 10) i ORDER BY i;
+
+
+--- check total was inserted
+SELECT SUM(count) FROM(
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=0
+UNION ALL
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=1
+UNION ALL
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=2
+UNION ALL
+SELECT COUNT(*) FROM kafka_test_prod_json WHERE offs >= 0 and part=3
+)t;
+
+--- check auto distribution makes sense
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=0;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=1;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=2;
+SELECT COUNT(*) BETWEEN 150 AND 350 FROM kafka_test_prod_json WHERE offs >= 0 and part=3;
+
+
+--- check data is readable
+SELECT some_int, some_text, some_date FROM(
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=0 AND some_int = 231 LIMIT 1)
+UNION ALL
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=1 AND some_int = 231 LIMIT 1)
+UNION ALL
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=2 AND some_int = 231 LIMIT 1)
+UNION ALL
+(SELECT some_int, some_text, some_date FROM kafka_test_prod_json WHERE offs >= 0 and part=3 AND some_int = 231 LIMIT 1)
+)t;

--- a/test/sql/json_test.sql
+++ b/test/sql/json_test.sql
@@ -1,0 +1,20 @@
+-- standard setup
+CREATE FOREIGN TABLE kafka_test_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json', batch_size '30', buffer_delay '100');
+
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 0 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 10 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 100 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 1000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 10000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 90000 LIMIT 30;
+SELECT * FROM kafka_test_json WHERE part = 0 AND offs > 100000 LIMIT 30;

--- a/test/sql/junk_test.sql
+++ b/test/sql/junk_test.sql
@@ -11,6 +11,20 @@ CREATE FOREIGN TABLE kafka_test_junk (
 SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100');
 
+CREATE FOREIGN TABLE kafka_test_junk_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    int_val int,
+    text_val text,
+    date_val date,
+    time_val timestamp,
+    junk text OPTIONS (junk 'true'),
+    junk_err text OPTIONS (junk_error 'true')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json_junk', batch_size '30', buffer_delay '100');
+
 \x on
-with kafkadata as ( SELECT * FROM kafka_test_junk WHERE offs>=0 and part=0 )
-SELECT part, offs, some_int, some_text, some_date, some_time, junk, string_to_array(junk_err, E'\n')  FROM kafkadata;
+SELECT part, offs, some_int, some_text, some_date, some_time, junk, string_to_array(junk_err, E'\n')  FROM kafka_test_junk WHERE offs>=0 and part=0 ;
+
+SELECT part, offs, int_val, text_val, date_val, time_val, junk, string_to_array(junk_err, E'\n')  FROM kafka_test_junk_json WHERE offs>=0 and part=0 ;

--- a/test/sql/kafka_test.sql
+++ b/test/sql/kafka_test.sql
@@ -59,7 +59,7 @@ SELECT COUNT(*) FROM kafka_test_part WHERE part = 4 AND offs >= 0
 -- see that we can properly parse messages
 SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 0 LIMIT 30;
 SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 10 LIMIT 30;
-SELECT * FROM kafka_test_single_part WHERE part = 1 AND offs > 100 LIMIT 30;
+SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 100 LIMIT 30;
 SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 1000 LIMIT 30;
 SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 10000 LIMIT 30;
 SELECT * FROM kafka_test_single_part WHERE part = 0 AND offs > 90000 LIMIT 30;

--- a/test/sql/strict_test.sql
+++ b/test/sql/strict_test.sql
@@ -9,7 +9,16 @@ CREATE FOREIGN TABLE kafka_strict (
 SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', strict 'true');
 
-SELECT * FROM kafka_strict WHERE offs>=0 and part=0;
+SELECT * FROM kafka_strict WHERE offs=0 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=1 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=2 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=3 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=4 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=5 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=6 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=8 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=9 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict WHERE offs=10 and part=0 LIMIT 1;
 
 CREATE FOREIGN TABLE kafka_ignore_junk (
     part int OPTIONS (partition 'true'),
@@ -23,4 +32,41 @@ SERVER kafka_server OPTIONS
     (format 'csv', topic 'contrib_regress_junk', batch_size '30', buffer_delay '100', ignore_junk 'true');
 
 SELECT * FROM kafka_ignore_junk WHERE offs>=0 and part=0;
+
+
+CREATE FOREIGN TABLE kafka_strict_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    text_val text,
+    some_date date OPTIONS (json 'date_val'),
+    time_val timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json_junk', batch_size '30', buffer_delay '100', strict 'true');
+
+SELECT * FROM kafka_strict_json WHERE offs=0 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=1 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=2 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=3 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=4 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=5 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=6 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=8 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=9 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=10 and part=0 LIMIT 1;
+SELECT * FROM kafka_strict_json WHERE offs=11 and part=0 LIMIT 1;
+
+CREATE FOREIGN TABLE kafka_ignore_junk_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    text_val text,
+    some_date date OPTIONS (json 'date_val'),
+    time_val timestamp
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json_junk', batch_size '30', buffer_delay '100', ignore_junk 'true');
+
+SELECT * FROM kafka_ignore_junk_json WHERE offs>=0 and part=0;
 


### PR DESCRIPTION
adds json to the format table option
the mapping between key and column can be
configured via `json` attribute option otherwise
the column name is used.

see
- test/sql/json_test.sql
- test/sql/json_producer_test.sql

for examples