### PR TITLE
Fix warnings

### DIFF
--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -228,14 +228,12 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
     Cost               total_cost;
     List *             columns;
     List *             options = NIL;
-    TupleDesc          tupdesc;
     Relation           relation;
     List *             conditions = baserel->baserestrictinfo;
     ListCell *         lc;
     KafkaOptions *     kafka_options = &fdw_private->kafka_options;
 
     relation = relation_open(foreigntableid, AccessShareLock);
-    tupdesc  = relation->rd_att;
 
     /*
      * write offset and partition to kafka_options.
@@ -356,10 +354,8 @@ kafkaExplainForeignScan(ForeignScanState *node, ExplainState *es)
 {
 
     KafkaOptions kafka_options;
-    ParseOptions parse_options;
     List *       fdw_private = ((ForeignScan *) node->ss.ps.plan)->fdw_private;
     kafka_options            = *(KafkaOptions *) list_nth(fdw_private, 0);
-    parse_options            = *(ParseOptions *) list_nth(fdw_private, 1);
 
     /* Fetch options --- we only need topic at this point */
     // kafkaGetOptions(RelationGetRelid(node->ss.ss_currentRelation), &kafka_options, &parse_options);
@@ -690,13 +686,11 @@ kafkaIterateForeignScan(ForeignScanState *node)
             }
             PG_CATCH();
             {
-                MemoryContext ecxt;
-
                 values[m]     = (Datum) 0;
                 nulls[m]      = true;
                 catched_error = true;
 
-                ecxt = MemoryContextSwitchTo(ccxt);
+                MemoryContextSwitchTo(ccxt);
 
                 /* accumulate errors if needed */
                 if (kafka_options->junk_error_attnum != -1)

--- a/src/option.c
+++ b/src/option.c
@@ -73,16 +73,17 @@ static void get_kafka_fdw_attribute_options(Oid relid, KafkaOptions *kafka_optio
 PG_FUNCTION_INFO_V1(kafka_fdw_validator);
 Datum kafka_fdw_validator(PG_FUNCTION_ARGS)
 {
-    DEBUGLOG("%s", __func__);
-
-    List *    options_list = untransformRelOptions(PG_GETARG_DATUM(0));
-    Oid       catalog      = PG_GETARG_OID(1);
+    List *    options_list;
+    Oid       catalog = PG_GETARG_OID(1);
     ListCell *cell;
+
+    DEBUGLOG("%s", __func__);
 
     /*
      * Check that only options supported by kafka_fdw, and allowed for the
      * current object type, are given.
      */
+    options_list = untransformRelOptions(PG_GETARG_DATUM(0));
     foreach (cell, options_list)
     {
         DefElem *def = (DefElem *) lfirst(cell);

--- a/src/parser.c
+++ b/src/parser.c
@@ -58,8 +58,6 @@ static void composite_to_json(Datum composite, StringInfo result, bool use_line_
 int
 KafkaReadAttributesCSV(char *msg, int msg_len, KafkaFdwExecutionState *festate, bool *unterminated_error)
 {
-    DEBUGLOG("%s", __func__);
-
     char  delimc  = festate->parse_options.delim[0];
     char  quotec  = festate->parse_options.quote[0];
     char  escapec = festate->parse_options.escape[0];
@@ -67,6 +65,8 @@ KafkaReadAttributesCSV(char *msg, int msg_len, KafkaFdwExecutionState *festate, 
     char *output_ptr;
     char *cur_ptr;
     char *line_end_ptr;
+
+    DEBUGLOG("%s", __func__);
 
     *unterminated_error = false;
     resetStringInfo(&festate->attribute_buf);
@@ -226,8 +226,6 @@ KafkaReadAttributesCSV(char *msg, int msg_len, KafkaFdwExecutionState *festate, 
 void
 KafkaWriteAttributesCSV(KafkaFdwModifyState *festate, TupleTableSlot *slot)
 {
-    DEBUGLOG("%s", __func__);
-
     ListCell *lc;
 
     char  delimc         = festate->parse_options.delim[0];
@@ -236,6 +234,8 @@ KafkaWriteAttributesCSV(KafkaFdwModifyState *festate, TupleTableSlot *slot)
     char *null_print     = festate->parse_options.null_print;
     int   null_print_len = festate->parse_options.null_print_len;
     int   pindex         = 0;
+
+    DEBUGLOG("%s", __func__);
 
     foreach (lc, festate->attnumlist)
     {
@@ -931,8 +931,6 @@ add_json(Datum val, bool is_null, StringInfo result, Oid val_type, bool key_scal
 void
 KafkaWriteAttributesJson(KafkaFdwModifyState *festate, TupleTableSlot *slot)
 {
-    DEBUGLOG("%s", __func__);
-
     /* much like json_build_object */
     ListCell *  lc;
     int         pindex   = 0;
@@ -940,14 +938,18 @@ KafkaWriteAttributesJson(KafkaFdwModifyState *festate, TupleTableSlot *slot)
     char **     attnames = festate->attnames;
     StringInfo  result   = &festate->attribute_buf;
 
+    DEBUGLOG("%s", __func__);
+
     appendStringInfoCharMacro(result, '{');
     foreach (lc, festate->attnumlist)
     {
-        DEBUGLOG("attname %s", *attnames);
-        DEBUGLOG("typeoid %u", *festate->typioparams);
         bool  isnull;
         int   attnum = lfirst_int(lc);
         Datum value  = slot_getattr(slot, attnum, &isnull);
+
+        DEBUGLOG("attname %s", *attnames);
+        DEBUGLOG("typeoid %u", *festate->typioparams);
+
         if (pindex > 0)
             appendStringInfoString(result, sep);
 


### PR DESCRIPTION
When building with gcc I get a bunch of warnings like:
```
warning: ISO C90 forbids mixed declarations and code
```
and
```
warning: variable 'values' set but not used
```
Fixed in the suggested pull request.