### PR TITLE
Fixing errors when cassert is enabled.

### DIFF
--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -1071,7 +1071,8 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
 
     foreach (lc, festate->attnumlist)
     {
-        if (del){
+        if (del)
+        {
              festate->attnumlist = list_delete_cell(festate->attnumlist, del, delprev);
              del  = NULL;
              delprev = NULL;
@@ -1111,7 +1112,8 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
     /* If internal column is at the end, this may still require deletion after.
      * So we will do that here.
      */
-    if (del){
+    if (del)
+    {
          festate->attnumlist = list_delete_cell(festate->attnumlist, del, delprev);
          del  = NULL;
          delprev = NULL;

--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -1028,7 +1028,7 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
     Oid                  typefnoid;
     bool                 isvarlena;
     int                  n_params, num = 0;
-    ListCell *           lc, *prev;
+    ListCell *           lc, *prev, *del, *delprev;
     KafkaOptions         kafka_options = { DEFAULT_KAFKA_OPTIONS };
     ParseOptions         parse_options = { .format = -1 };
     Relation             rel           = rinfo->ri_RelationDesc;
@@ -1066,13 +1066,26 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
     initStringInfo(&festate->attribute_buf);
 
     prev = NULL;
+    del  = NULL;
+    delprev = NULL;
 
     foreach (lc, festate->attnumlist)
     {
+        if (del){
+             festate->attnumlist = list_delete_cell(festate->attnumlist, del, delprev);
+             del  = NULL;
+             delprev = NULL;
+        }
+           
         int attnum = lfirst_int(lc);
+
+        /* For Kafka internal columns we cannot delete in the loop because that causes issues.
+         * Therefore we mark for deletion on next loop cycle.
+         */
         if (!parsable_attnum(attnum, kafka_options))
         {
-            festate->attnumlist = list_delete_cell(festate->attnumlist, lc, prev);
+             del = lc;
+             delprev = prev;
         }
         else
         {
@@ -1093,6 +1106,15 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
             num++;
             prev = lc;
         }
+    }
+
+    /* If internal column is at the end, this may still require deletion after.
+     * So we will do that here.
+     */
+    if (del){
+         festate->attnumlist = list_delete_cell(festate->attnumlist, del, delprev);
+         del  = NULL;
+         delprev = NULL;
     }
 
     conf = rd_kafka_conf_new();


### PR DESCRIPTION
Since casserts among other things zero freed memory, this means that list manipulations we were using only work
when these are disabled, and that makes testing problematic.