### PR TITLE
raw and custom scan

### DIFF
--- a/src/custom.c
+++ b/src/custom.c
@@ -1,0 +1,20 @@
+#include "postgres.h"
+void kafka_custom_msglen(char *msgstr, size_t msg_len, Datum *values, bool *nulls, int num_attr, int pidx, int oidx);
+
+/*
+ * example for a custom scan implementation
+ * we don't do anything with the message itself here just
+ * callback the message size into the Datums array
+ */
+void
+kafka_custom_msglen(char *msgstr, size_t msg_len, Datum *values, bool *nulls, int num_attr, int pidx, int oidx)
+{
+    for (int i = 0; i < num_attr; i++)
+    {
+        if (!(i == pidx || i == oidx))
+        {
+            nulls[i]  = false;
+            values[i] = Int32GetDatum((int32) msg_len);
+        }
+    }
+}

--- a/src/kafka_expr.c
+++ b/src/kafka_expr.c
@@ -432,7 +432,7 @@ KafkaFlattenScanlist(List *              scan_list,
             }
         }
     }
-    expandKafkaScanPData(scanp_data, batch_size);
+    // expandKafkaScanPData(scanp_data, batch_size);
 }
 
 /* expand the list into chunks off batch_size*/

--- a/src/kafka_expr.c
+++ b/src/kafka_expr.c
@@ -435,7 +435,7 @@ KafkaFlattenScanlist(List *              scan_list,
     // expandKafkaScanPData(scanp_data, batch_size);
 }
 
-/* expand the list into chunks off batch_size*/
+/* expand the list into chunks off batch_size */
 static void
 expandKafkaScanPData(KafkaScanPData *scanp_data, int64 batch_size)
 {

--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -202,29 +202,30 @@ typedef struct KafkaScanPData
  */
 typedef struct KafkaFdwExecutionState
 {
-    KafkaOptions         kafka_options;      /* kafka optopns */
-    ParseOptions         parse_options;      /* merged COPY options */
-    rd_kafka_t *         kafka_handle;       /* connection to act on */
-    rd_kafka_topic_t *   kafka_topic_handle; /* topic to act on */
-    rd_kafka_message_t **buffer;             /* message buffer */
-    StringInfoData       attribute_buf;      /* reused attribute buffer */
-    StringInfoData       junk_buf;           /* reused buffer for junk error messages */
-    char **              raw_fields;         /* pointers into attribute_buf */
-    int                  max_fields;         /* max number of raw_fields */
-    ssize_t              buffer_count;       /* number of messages currently in buffer*/
-    ssize_t              buffer_cursor;      /* current message */
-    FmgrInfo *           in_functions;       /* array of input functions for each attrs */
-    Oid *                typioparams;        /* array of element types for in_functions */
-    List *               attnumlist;         /* integer list of attnums to copy */
-    List *               scanop_list;        /* list of KafkaScanOpP to scan */
-    List *               exec_exprs;         /* expressions to evaluate */
-    KafkaParamValue *    param_values;       /* param_value List matching exec_expr */
-    KafKaPartitionList * partition_list;     /* list and count of partitions */
-    KafkaScanPData *     scan_data;          /* scan data list  */
-    StringInfoData       attname_buf;        /* buffer holding attribute names for json format */
-    char **              attnames;           /* pointer into attname_buf */
-    KafkaScanDataDesc *  scan_data_desc;     /* coordination point for parallel scans */
-    custom_decoder       decode;             /* custom decode function */
+    KafkaOptions         kafka_options;        /* kafka optopns */
+    ParseOptions         parse_options;        /* merged COPY options */
+    rd_kafka_t *         kafka_handle;         /* connection to act on */
+    rd_kafka_topic_t *   kafka_topic_handle;   /* topic to act on */
+    rd_kafka_message_t **buffer;               /* message buffer */
+    StringInfoData       attribute_buf;        /* reused attribute buffer */
+    StringInfoData       junk_buf;             /* reused buffer for junk error messages */
+    char **              raw_fields;           /* pointers into attribute_buf */
+    int                  max_fields;           /* max number of raw_fields */
+    ssize_t              buffer_count;         /* number of messages currently in buffer*/
+    ssize_t              buffer_cursor;        /* current message */
+    FmgrInfo *           in_functions;         /* array of input functions for each attrs */
+    Oid *                typioparams;          /* array of element types for in_functions */
+    List *               attnumlist;           /* integer list of attnums to copy */
+    List *               scanop_list;          /* list of KafkaScanOpP to scan */
+    List *               exec_exprs;           /* expressions to evaluate */
+    KafkaParamValue *    param_values;         /* param_value List matching exec_expr */
+    KafKaPartitionList * partition_list;       /* list and count of partitions */
+    KafkaScanPData *     scan_data;            /* scan data list  */
+    StringInfoData       attname_buf;          /* buffer holding attribute names for json format */
+    char **              attnames;             /* pointer into attname_buf */
+    KafkaScanDataDesc *  scan_data_desc;       /* coordination point for parallel scans */
+    custom_decoder       decode;               /* custom decode function */
+    bool                 offset_limit_reached; /* did the scan reach the offset limit*/
 } KafkaFdwExecutionState;
 
 /*

--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -185,13 +185,8 @@ typedef struct KafkaFdwPlanState
     int          npart;         /* estimate of number of partitions to scan */
 } KafkaFdwPlanState;
 
-typedef void (*custom_decoder)(char * msg,
-                               size_t msg_len,
-                               Datum *values,
-                               bool * nulls,
-                               int    num_attr,
-                               int    part_attnum,
-                               int    offset_attnum);
+typedef void (
+  *custom_decoder)(char *msg, size_t msg_len, Datum *values, bool *nulls, int num_attr, int part_idx, int offset_idx);
 
 /* holds information about extensible KafkaScanP list */
 typedef struct KafkaScanPData

--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -68,7 +68,8 @@ enum kafka_msg_format
 {
     INVALID = -1,
     JSON,
-    CSV
+    CSV,
+    RAW
 };
 
 typedef enum kafka_op

--- a/src/option.c
+++ b/src/option.c
@@ -195,6 +195,8 @@ KafkaProcessParseOptions(ParseOptions *parse_options, List *options)
             }
             else if (strcmp(fmt, "json") == 0)
                 parse_options->format = JSON;
+            else if (strcmp(fmt, "raw") == 0)
+                parse_options->format = RAW;
             else
                 ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("format \"%s\" not recognized", fmt)));
         }

--- a/src/planning.c
+++ b/src/planning.c
@@ -115,5 +115,6 @@ KafkaSetParallelPath(Path *path, int num_workers, Cost startup_cost, Cost total_
     path->total_cost       = startup_cost + run_cost / parallel_divisor;
     path->parallel_aware   = true;
     path->parallel_workers = num_workers;
+    path->parallel_safe    = true;
 }
 #endif

--- a/test/expected/custom.out
+++ b/test/expected/custom.out
@@ -1,0 +1,13 @@
+CREATE EXTENSION base36;
+CREATE FOREIGN TABLE kafka_test_custom (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    app_token bigbase36, tracker_id bigint, event_type_id int, app_version text
+)
+SERVER kafka_server OPTIONS
+    (format 'custom', decode_lib '$libdir/aj_proto', decode_func 'aj_proto_segment' ,topic 'backend', batch_size '30', buffer_delay '100');
+ERROR:  server "kafka_server" does not exist
+SELECT part, offs, app_token, tracker_id, event_type_id, app_version  FROM kafka_test_custom WHERE part=1 AND offs BETWEEN 1 AND 5 ORDER BY offs;
+ERROR:  relation "kafka_test_custom" does not exist
+LINE 1: ...ken, tracker_id, event_type_id, app_version  FROM kafka_test...
+                                                             ^

--- a/test/expected/custom_len_test.out
+++ b/test/expected/custom_len_test.out
@@ -1,0 +1,19 @@
+\i test/sql/setup.inc
+\set ECHO none
+CREATE FOREIGN TABLE kafka_test_custom (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    len int
+)
+SERVER kafka_server OPTIONS
+    (format 'custom', decode_lib '$libdir/kafka_fdw', decode_func 'kafka_custom_msglen' ,topic 'contrib_regress', batch_size '30', buffer_delay '500');
+SELECT part, offs, len  FROM kafka_test_custom WHERE offs BETWEEN 1 AND 5 ORDER BY offs;
+ part | offs | len 
+------+------+-----
+    0 |    1 |  73
+    0 |    2 |  73
+    0 |    3 |  73
+    0 |    4 |  73
+    0 |    5 |  73
+(5 rows)
+

--- a/test/expected/test_raw.out
+++ b/test/expected/test_raw.out
@@ -1,0 +1,24 @@
+CREATE FOREIGN TABLE kafka_test_raw (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    message text
+)
+SERVER kafka_server OPTIONS
+    (format 'raw', topic 'contrib_regress4', batch_size '30', buffer_delay '100');
+-- we can only check if the meesaage has a certain pattern as part / offs is not deteministic
+SELECT part, offs,  message ~ E'\\d{4},"It\'s some text, that is for number \\d{4}",\\d{4}-\\d{2}-\\d{2},\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}' FROM kafka_test_raw WHERE part=1 AND offs BETWEEN 100 AND 110 ORDER BY offs;
+ part | offs | ?column? 
+------+------+----------
+    1 |  100 | t
+    1 |  101 | t
+    1 |  102 | t
+    1 |  103 | t
+    1 |  104 | t
+    1 |  105 | t
+    1 |  106 | t
+    1 |  107 | t
+    1 |  108 | t
+    1 |  109 | t
+    1 |  110 | t
+(11 rows)
+

--- a/test/sql/custom_len_test.sql
+++ b/test/sql/custom_len_test.sql
@@ -1,0 +1,10 @@
+\i test/sql/setup.inc
+CREATE FOREIGN TABLE kafka_test_custom (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    len int
+)
+SERVER kafka_server OPTIONS
+    (format 'custom', decode_lib '$libdir/kafka_fdw', decode_func 'kafka_custom_msglen' ,topic 'contrib_regress', batch_size '30', buffer_delay '500');
+
+SELECT part, offs, len  FROM kafka_test_custom WHERE offs BETWEEN 1 AND 5 ORDER BY offs;

--- a/test/sql/test_raw.sql
+++ b/test/sql/test_raw.sql
@@ -1,0 +1,10 @@
+CREATE FOREIGN TABLE kafka_test_raw (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    message text
+)
+SERVER kafka_server OPTIONS
+    (format 'raw', topic 'contrib_regress4', batch_size '30', buffer_delay '100');
+
+-- we can only check if the meesaage has a certain pattern as part / offs is not deteministic
+SELECT part, offs,  message ~ E'\\d{4},"It\'s some text, that is for number \\d{4}",\\d{4}-\\d{2}-\\d{2},\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}' FROM kafka_test_raw WHERE part=1 AND offs BETWEEN 100 AND 110 ORDER BY offs;


### PR DESCRIPTION
this adds two new scan methods

* raw simply dumps the message into a single column with only using the columns type in function 
* custom allows the user to define a custom decoding function / dynamic lib which will be automatically loaded, the function `kafka_custom_msglen` is added here as a rather useless example

this also add the experimental `expandKafkaScanPData` methods which would split the expandKafkaScanPData into chunks of batch size allowing multiple parallel workers to do the job better, but this seems not to be very fruitfull

