### PR TITLE
Fix array parsing from JSON string

### DIFF
--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -208,6 +208,7 @@ typedef struct KafkaFdwExecutionState
     ssize_t              buffer_cursor;      /* current message */
     FmgrInfo *           in_functions;       /* array of input functions for each attrs */
     Oid *                typioparams;        /* array of element types for in_functions */
+    Bitmapset *          attisarray;         /* bitmap of attributes of array type */
     List *               attnumlist;         /* integer list of attnums to copy */
     List *               scanop_list;        /* list of KafkaScanOpP to scan */
     List *               exec_exprs;         /* expressions to evaluate */

--- a/test/expected/json_producer_test.out
+++ b/test/expected/json_producer_test.out
@@ -6,35 +6,36 @@ CREATE FOREIGN TABLE kafka_test_prod_json (
     some_int int,
     some_text text,
     some_date date,
-    some_time timestamp
+    some_time timestamp,
+    some_array text[]
 )
 SERVER kafka_server OPTIONS
     (format 'json', topic 'contrib_regress_prod_json', batch_size '3000', buffer_delay '100');
-INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date)
+INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date, some_array)
     VALUES
-    (1, 1,'foo bar 1','2017-01-01'),
-    (1, 2,'foo text 2','2017-01-02'),
-    (1, 3,'foo text 3','2017-01-03'),
-    (1, 4,'foo text 4','2017-01-04'),
-    (1, 5,'foo text 5','2017-01-05'),
-    (1, 6,'foo text 6','2017-01-06'),
-    (1, 7,'foo bar 7','2017-01-07'),
-    (1, 8,'foo text 8','2017-01-08'),
-    (1, 9,'foo text 9','2017-01-09'),
-    (1, 10,'foo text 10','2017-01-10')
+    (1, 1,'foo bar 1','2017-01-01', array[1,2,3]),
+    (1, 2,'foo text 2','2017-01-02', array[[1,2], [3,4]]),
+    (1, 3,'foo text 3','2017-01-03', array['test [brackets]', 'test "[brackets]" in quotes']),
+    (1, 4,'foo text 4','2017-01-04', NULL),
+    (1, 5,'foo text 5','2017-01-05', NULL),
+    (1, 6,'foo text 6','2017-01-06', NULL),
+    (1, 7,'foo bar 7','2017-01-07', NULL),
+    (1, 8,'foo text 8','2017-01-08', NULL),
+    (1, 9,'foo text 9','2017-01-09', NULL),
+    (1, 10,'foo text 10','2017-01-10', NULL)
 RETURNING *;
- part | offs | some_int |  some_text  | some_date  | some_time 
-------+------+----------+-------------+------------+-----------
-    1 |      |        1 | foo bar 1   | 01-01-2017 | 
-    1 |      |        2 | foo text 2  | 01-02-2017 | 
-    1 |      |        3 | foo text 3  | 01-03-2017 | 
-    1 |      |        4 | foo text 4  | 01-04-2017 | 
-    1 |      |        5 | foo text 5  | 01-05-2017 | 
-    1 |      |        6 | foo text 6  | 01-06-2017 | 
-    1 |      |        7 | foo bar 7   | 01-07-2017 | 
-    1 |      |        8 | foo text 8  | 01-08-2017 | 
-    1 |      |        9 | foo text 9  | 01-09-2017 | 
-    1 |      |       10 | foo text 10 | 01-10-2017 | 
+ part | offs | some_int |  some_text  | some_date  | some_time |                     some_array                      
+------+------+----------+-------------+------------+-----------+-----------------------------------------------------
+    1 |      |        1 | foo bar 1   | 01-01-2017 |           | {1,2,3}
+    1 |      |        2 | foo text 2  | 01-02-2017 |           | {{1,2},{3,4}}
+    1 |      |        3 | foo text 3  | 01-03-2017 |           | {"test [brackets]","test \"[brackets]\" in quotes"}
+    1 |      |        4 | foo text 4  | 01-04-2017 |           | 
+    1 |      |        5 | foo text 5  | 01-05-2017 |           | 
+    1 |      |        6 | foo text 6  | 01-06-2017 |           | 
+    1 |      |        7 | foo bar 7   | 01-07-2017 |           | 
+    1 |      |        8 | foo text 8  | 01-08-2017 |           | 
+    1 |      |        9 | foo text 9  | 01-09-2017 |           | 
+    1 |      |       10 | foo text 10 | 01-10-2017 |           | 
 (10 rows)
 
 -- run some memload
@@ -81,18 +82,18 @@ select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
 (1 row)
 
 SELECT * FROM kafka_test_prod_json WHERE offs >= 0 and part=1;
- part | offs | some_int |  some_text  | some_date  | some_time 
-------+------+----------+-------------+------------+-----------
-    1 |    0 |        1 | foo bar 1   | 01-01-2017 | 
-    1 |    1 |        2 | foo text 2  | 01-02-2017 | 
-    1 |    2 |        3 | foo text 3  | 01-03-2017 | 
-    1 |    3 |        4 | foo text 4  | 01-04-2017 | 
-    1 |    4 |        5 | foo text 5  | 01-05-2017 | 
-    1 |    5 |        6 | foo text 6  | 01-06-2017 | 
-    1 |    6 |        7 | foo bar 7   | 01-07-2017 | 
-    1 |    7 |        8 | foo text 8  | 01-08-2017 | 
-    1 |    8 |        9 | foo text 9  | 01-09-2017 | 
-    1 |    9 |       10 | foo text 10 | 01-10-2017 | 
+ part | offs | some_int |  some_text  | some_date  | some_time |                     some_array                      
+------+------+----------+-------------+------------+-----------+-----------------------------------------------------
+    1 |    0 |        1 | foo bar 1   | 01-01-2017 |           | {1,2,3}
+    1 |    1 |        2 | foo text 2  | 01-02-2017 |           | {{1,2},{3,4}}
+    1 |    2 |        3 | foo text 3  | 01-03-2017 |           | {"test [brackets]","test \"[brackets]\" in quotes"}
+    1 |    3 |        4 | foo text 4  | 01-04-2017 |           | 
+    1 |    4 |        5 | foo text 5  | 01-05-2017 |           | 
+    1 |    5 |        6 | foo text 6  | 01-06-2017 |           | 
+    1 |    6 |        7 | foo bar 7   | 01-07-2017 |           | 
+    1 |    7 |        8 | foo text 8  | 01-08-2017 |           | 
+    1 |    8 |        9 | foo text 9  | 01-09-2017 |           | 
+    1 |    9 |       10 | foo text 10 | 01-10-2017 |           | 
 (10 rows)
 
 INSERT INTO kafka_test_prod_json(some_int, some_text, some_date, some_time)

--- a/test/sql/json_producer_test.sql
+++ b/test/sql/json_producer_test.sql
@@ -5,23 +5,24 @@ CREATE FOREIGN TABLE kafka_test_prod_json (
     some_int int,
     some_text text,
     some_date date,
-    some_time timestamp
+    some_time timestamp,
+    some_array text[]
 )
 SERVER kafka_server OPTIONS
     (format 'json', topic 'contrib_regress_prod_json', batch_size '3000', buffer_delay '100');
 
-INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date)
+INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date, some_array)
     VALUES
-    (1, 1,'foo bar 1','2017-01-01'),
-    (1, 2,'foo text 2','2017-01-02'),
-    (1, 3,'foo text 3','2017-01-03'),
-    (1, 4,'foo text 4','2017-01-04'),
-    (1, 5,'foo text 5','2017-01-05'),
-    (1, 6,'foo text 6','2017-01-06'),
-    (1, 7,'foo bar 7','2017-01-07'),
-    (1, 8,'foo text 8','2017-01-08'),
-    (1, 9,'foo text 9','2017-01-09'),
-    (1, 10,'foo text 10','2017-01-10')
+    (1, 1,'foo bar 1','2017-01-01', array[1,2,3]),
+    (1, 2,'foo text 2','2017-01-02', array[[1,2], [3,4]]),
+    (1, 3,'foo text 3','2017-01-03', array['test [brackets]', 'test "[brackets]" in quotes']),
+    (1, 4,'foo text 4','2017-01-04', NULL),
+    (1, 5,'foo text 5','2017-01-05', NULL),
+    (1, 6,'foo text 6','2017-01-06', NULL),
+    (1, 7,'foo bar 7','2017-01-07', NULL),
+    (1, 8,'foo text 8','2017-01-08', NULL),
+    (1, 9,'foo text 9','2017-01-09', NULL),
+    (1, 10,'foo text 10','2017-01-10', NULL)
 
 RETURNING *;
 


### PR DESCRIPTION
I encountered a problem with reading arrays from Kafka when using JSON format:
```sql
select * from kafka_json;
ERROR:  malformed array literal: “[5,6,7]”
```

I've added an additional transformation step for attributes of array types. Please take a look. Probably you may think of a better solution?