### PR TITLE
Expand coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ before_install:
 script:
   - KAFKA_PRODUCER=$PWD/kafka/bin/kafka-console-producer.sh KAFKA_TOPICS=$PWD/kafka/bin/kafka-topics.sh make installcheck
 after_failure:
-  - cat /home/travis/build/adjust/kafka_fdw/regression.diffs
+  - cat regression.diffs

--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -172,7 +172,8 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
                                                  NULL, /* no extra plan */
                                                  NIL);
 #ifdef DO_PARALLEL
-    if (num_workers > 0)
+    /* Cannot add parameterized path as partial path */
+    if (num_workers > 0 && baserel->consider_parallel)
     {
         KafkaSetParallelPath((Path *) foreign_path, num_workers, startup_cost, total_cost, run_cost);
         add_partial_path(baserel, (Path *) foreign_path);

--- a/test/expected/json_producer_test.out
+++ b/test/expected/json_producer_test.out
@@ -1,5 +1,6 @@
 \i test/sql/setup.inc
 \set ECHO none
+CREATE TYPE my_type AS (a int, b text);
 CREATE FOREIGN TABLE kafka_test_prod_json (
     part int OPTIONS (partition 'true'),
     offs bigint OPTIONS (offset 'true'),
@@ -7,35 +8,38 @@ CREATE FOREIGN TABLE kafka_test_prod_json (
     some_text text,
     some_date date,
     some_time timestamp,
-    some_array text[]
+    some_timetz timestamptz,
+    some_array text[],
+    some_custom_type my_type,
+    some_json jsonb
 )
 SERVER kafka_server OPTIONS
     (format 'json', topic 'contrib_regress_prod_json', batch_size '3000', buffer_delay '100');
-INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date, some_array)
+INSERT INTO kafka_test_prod_json(part, some_int, some_text, some_date, some_time, some_timetz, some_json, some_array)
     VALUES
-    (1, 1,'foo bar 1','2017-01-01', array[1,2,3]),
-    (1, 2,'foo text 2','2017-01-02', array[[1,2], [3,4]]),
-    (1, 3,'foo text 3','2017-01-03', array['test [brackets]', 'test "[brackets]" in quotes']),
-    (1, 4,'foo text 4','2017-01-04', NULL),
-    (1, 5,'foo text 5','2017-01-05', NULL),
-    (1, 6,'foo text 6','2017-01-06', NULL),
-    (1, 7,'foo bar 7','2017-01-07', NULL),
-    (1, 8,'foo text 8','2017-01-08', NULL),
-    (1, 9,'foo text 9','2017-01-09', NULL),
-    (1, 10,'foo text 10','2017-01-10', NULL)
+    (1, 1,'foo bar 1',   '2017-01-01', '2017-01-01 00:00:01', '2017-01-01 00:00:01', '{"a": 1, "b": 10}', array[1,2,3]),
+    (1, 2,'foo text 2',  '2017-01-02', '2017-01-02 00:00:01', '2017-01-02 00:00:01', '{"a": 2, "b": 9}',  array[[1,2], [3,4]]),
+    (1, 3,'foo text 3',  '2017-01-03', '2017-01-03 00:00:01', '2017-01-03 00:00:01', '{"a": 3, "b": 8}',  array['test [brackets]', 'test "[brackets]" in quotes']),
+    (1, 4,'foo text 4',  '2017-01-04', '2017-01-04 00:00:01', '2017-01-04 00:00:01', '{"a": 4, "b": 7}',  NULL),
+    (1, 5,'foo text 5',  '2017-01-05', '2017-01-05 00:00:01', '2017-01-05 00:00:01', '{"a": 5, "b": 6}',  NULL),
+    (1, 6,'foo text 6',  '2017-01-06', '2017-01-06 00:00:01', '2017-01-06 00:00:01', '{"a": 6, "b": 5}',  NULL),
+    (1, 7,'foo bar 7',   '2017-01-07', '2017-01-07 00:00:01', '2017-01-07 00:00:01', '{"a": 7, "b": 4}',  NULL),
+    (1, 8,'foo text 8',  '2017-01-08', '2017-01-08 00:00:01', '2017-01-08 00:00:01', '{"a": 8, "b": 3}',  NULL),
+    (1, 9,'foo text 9',  '2017-01-09', '2017-01-09 00:00:01', '2017-01-09 00:00:01', '{"a": 9, "b": 2}',  NULL),
+    (1, 10,'foo text 10','2017-01-10', '2017-01-10 00:00:01', '2017-01-10 00:00:01', '{"a": 10, "b": 1}', NULL)
 RETURNING *;
- part | offs | some_int |  some_text  | some_date  | some_time |                     some_array                      
-------+------+----------+-------------+------------+-----------+-----------------------------------------------------
-    1 |      |        1 | foo bar 1   | 01-01-2017 |           | {1,2,3}
-    1 |      |        2 | foo text 2  | 01-02-2017 |           | {{1,2},{3,4}}
-    1 |      |        3 | foo text 3  | 01-03-2017 |           | {"test [brackets]","test \"[brackets]\" in quotes"}
-    1 |      |        4 | foo text 4  | 01-04-2017 |           | 
-    1 |      |        5 | foo text 5  | 01-05-2017 |           | 
-    1 |      |        6 | foo text 6  | 01-06-2017 |           | 
-    1 |      |        7 | foo bar 7   | 01-07-2017 |           | 
-    1 |      |        8 | foo text 8  | 01-08-2017 |           | 
-    1 |      |        9 | foo text 9  | 01-09-2017 |           | 
-    1 |      |       10 | foo text 10 | 01-10-2017 |           | 
+ part | offs | some_int |  some_text  | some_date  |        some_time         |         some_timetz          |                     some_array                      | some_custom_type |     some_json     
+------+------+----------+-------------+------------+--------------------------+------------------------------+-----------------------------------------------------+------------------+-------------------
+    1 |      |        1 | foo bar 1   | 01-01-2017 | Sun Jan 01 00:00:01 2017 | Sun Jan 01 00:00:01 2017 PST | {1,2,3}                                             |                  | {"a": 1, "b": 10}
+    1 |      |        2 | foo text 2  | 01-02-2017 | Mon Jan 02 00:00:01 2017 | Mon Jan 02 00:00:01 2017 PST | {{1,2},{3,4}}                                       |                  | {"a": 2, "b": 9}
+    1 |      |        3 | foo text 3  | 01-03-2017 | Tue Jan 03 00:00:01 2017 | Tue Jan 03 00:00:01 2017 PST | {"test [brackets]","test \"[brackets]\" in quotes"} |                  | {"a": 3, "b": 8}
+    1 |      |        4 | foo text 4  | 01-04-2017 | Wed Jan 04 00:00:01 2017 | Wed Jan 04 00:00:01 2017 PST |                                                     |                  | {"a": 4, "b": 7}
+    1 |      |        5 | foo text 5  | 01-05-2017 | Thu Jan 05 00:00:01 2017 | Thu Jan 05 00:00:01 2017 PST |                                                     |                  | {"a": 5, "b": 6}
+    1 |      |        6 | foo text 6  | 01-06-2017 | Fri Jan 06 00:00:01 2017 | Fri Jan 06 00:00:01 2017 PST |                                                     |                  | {"a": 6, "b": 5}
+    1 |      |        7 | foo bar 7   | 01-07-2017 | Sat Jan 07 00:00:01 2017 | Sat Jan 07 00:00:01 2017 PST |                                                     |                  | {"a": 7, "b": 4}
+    1 |      |        8 | foo text 8  | 01-08-2017 | Sun Jan 08 00:00:01 2017 | Sun Jan 08 00:00:01 2017 PST |                                                     |                  | {"a": 8, "b": 3}
+    1 |      |        9 | foo text 9  | 01-09-2017 | Mon Jan 09 00:00:01 2017 | Mon Jan 09 00:00:01 2017 PST |                                                     |                  | {"a": 9, "b": 2}
+    1 |      |       10 | foo text 10 | 01-10-2017 | Tue Jan 10 00:00:01 2017 | Tue Jan 10 00:00:01 2017 PST |                                                     |                  | {"a": 10, "b": 1}
 (10 rows)
 
 -- run some memload
@@ -82,18 +86,18 @@ select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;
 (1 row)
 
 SELECT * FROM kafka_test_prod_json WHERE offs >= 0 and part=1;
- part | offs | some_int |  some_text  | some_date  | some_time |                     some_array                      
-------+------+----------+-------------+------------+-----------+-----------------------------------------------------
-    1 |    0 |        1 | foo bar 1   | 01-01-2017 |           | {1,2,3}
-    1 |    1 |        2 | foo text 2  | 01-02-2017 |           | {{1,2},{3,4}}
-    1 |    2 |        3 | foo text 3  | 01-03-2017 |           | {"test [brackets]","test \"[brackets]\" in quotes"}
-    1 |    3 |        4 | foo text 4  | 01-04-2017 |           | 
-    1 |    4 |        5 | foo text 5  | 01-05-2017 |           | 
-    1 |    5 |        6 | foo text 6  | 01-06-2017 |           | 
-    1 |    6 |        7 | foo bar 7   | 01-07-2017 |           | 
-    1 |    7 |        8 | foo text 8  | 01-08-2017 |           | 
-    1 |    8 |        9 | foo text 9  | 01-09-2017 |           | 
-    1 |    9 |       10 | foo text 10 | 01-10-2017 |           | 
+ part | offs | some_int |  some_text  | some_date  |        some_time         |         some_timetz          |                     some_array                      | some_custom_type |     some_json     
+------+------+----------+-------------+------------+--------------------------+------------------------------+-----------------------------------------------------+------------------+-------------------
+    1 |    0 |        1 | foo bar 1   | 01-01-2017 | Sun Jan 01 00:00:01 2017 | Sun Jan 01 00:00:01 2017 PST | {1,2,3}                                             |                  | {"a": 1, "b": 10}
+    1 |    1 |        2 | foo text 2  | 01-02-2017 | Mon Jan 02 00:00:01 2017 | Mon Jan 02 00:00:01 2017 PST | {{1,2},{3,4}}                                       |                  | {"a": 2, "b": 9}
+    1 |    2 |        3 | foo text 3  | 01-03-2017 | Tue Jan 03 00:00:01 2017 | Tue Jan 03 00:00:01 2017 PST | {"test [brackets]","test \"[brackets]\" in quotes"} |                  | {"a": 3, "b": 8}
+    1 |    3 |        4 | foo text 4  | 01-04-2017 | Wed Jan 04 00:00:01 2017 | Wed Jan 04 00:00:01 2017 PST |                                                     |                  | {"a": 4, "b": 7}
+    1 |    4 |        5 | foo text 5  | 01-05-2017 | Thu Jan 05 00:00:01 2017 | Thu Jan 05 00:00:01 2017 PST |                                                     |                  | {"a": 5, "b": 6}
+    1 |    5 |        6 | foo text 6  | 01-06-2017 | Fri Jan 06 00:00:01 2017 | Fri Jan 06 00:00:01 2017 PST |                                                     |                  | {"a": 6, "b": 5}
+    1 |    6 |        7 | foo bar 7   | 01-07-2017 | Sat Jan 07 00:00:01 2017 | Sat Jan 07 00:00:01 2017 PST |                                                     |                  | {"a": 7, "b": 4}
+    1 |    7 |        8 | foo text 8  | 01-08-2017 | Sun Jan 08 00:00:01 2017 | Sun Jan 08 00:00:01 2017 PST |                                                     |                  | {"a": 8, "b": 3}
+    1 |    8 |        9 | foo text 9  | 01-09-2017 | Mon Jan 09 00:00:01 2017 | Mon Jan 09 00:00:01 2017 PST |                                                     |                  | {"a": 9, "b": 2}
+    1 |    9 |       10 | foo text 10 | 01-10-2017 | Tue Jan 10 00:00:01 2017 | Tue Jan 10 00:00:01 2017 PST |                                                     |                  | {"a": 10, "b": 1}
 (10 rows)
 
 INSERT INTO kafka_test_prod_json(some_int, some_text, some_date, some_time)
@@ -157,3 +161,5 @@ UNION ALL
       231 | It's some text, that is for number 231 | 01-01-2015
 (1 row)
 
+--- check exporting composite types to json format (importing is not yet supported)
+INSERT INTO kafka_test_prod_json (some_custom_type) VALUES ((1, 'test'));

--- a/test/expected/kafka_test.out
+++ b/test/expected/kafka_test.out
@@ -1,5 +1,39 @@
 \i test/sql/setup.inc
 \set ECHO none
+/*
+ * Returns EXPLAIN ANALYZE result without any arbitrary numbers like costs
+ * or execution time.
+ *
+ * In Postgres 10 there is a very convinient feature EXPLAIN (SUMMARY OFF),
+ * which removes 'Planning time' and 'Execution time' information lines from
+ * the result. Unfortunately we cannot use it on older PostgreSQL versions.
+ */
+CREATE OR REPLACE FUNCTION explain(query TEXT) RETURNS SETOF RECORD AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN EXECUTE 'EXPLAIN (COSTS OFF, TIMING OFF, ANALYZE) ' || query
+    LOOP
+        RETURN NEXT rec;
+    END LOOP;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION explain_invariant(query TEXT)
+RETURNS SETOF text AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT * FROM explain(query) as e(t text)
+    LOOP
+        IF position('Planning time' in rec.t) > 0 OR
+           position('Execution time' in rec.t) > 0
+        THEN
+            CONTINUE;
+        END IF;
+        RETURN NEXT rec.t;
+    END LOOP;
+END
+$$ LANGUAGE plpgsql;
 -- standard setup
 CREATE FOREIGN TABLE kafka_test_part (
     part int OPTIONS (partition 'true'),
@@ -163,14 +197,8 @@ EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE ((part = 1 or part = 2) 
 (8 rows)
 
 -- check parameterized queries
-SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0;
- part | offs | some_int |               some_text               | some_date  |        some_time         
-------+------+----------+---------------------------------------+------------+--------------------------
-    0 |    1 |       61 | It's some text, that is for number 61 | 01-01-2015 | Thu Jan 01 00:01:01 2015
-(1 row)
-
-EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0;
-                       QUERY PLAN                        
+SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0');
+                    explain_invariant                    
 ---------------------------------------------------------
  Foreign Scan on kafka_test_part (actual rows=1 loops=1)
    Filter: ((offs = $0) AND (part = 0))
@@ -180,14 +208,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_p
      ->  Result (actual rows=1 loops=1)
 (6 rows)
 
-SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1);
- part | offs | some_int |              some_text               | some_date  |        some_time         
-------+------+----------+--------------------------------------+------------+--------------------------
-    1 |    0 |        1 | It's some text, that is for number 1 | 01-01-2015 | Thu Jan 01 00:00:01 2015
-(1 row)
-
-EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1);
-                       QUERY PLAN                        
+SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1)');
+                    explain_invariant                    
 ---------------------------------------------------------
  Foreign Scan on kafka_test_part (actual rows=1 loops=1)
    Filter: ((offs = 0) AND (part = $0))
@@ -197,14 +219,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_p
      ->  Result (actual rows=1 loops=1)
 (6 rows)
 
-SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0;
- part | offs | some_int |               some_text               | some_date  |        some_time         
-------+------+----------+---------------------------------------+------------+--------------------------
-    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
-(1 row)
-
-EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0;
-                       QUERY PLAN                        
+SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0');
+                    explain_invariant                    
 ---------------------------------------------------------
  Foreign Scan on kafka_test_part (actual rows=1 loops=1)
    Filter: ((offs < $0) AND (part = 0))
@@ -214,15 +230,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_p
      ->  Result (actual rows=1 loops=1)
 (6 rows)
 
-SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0;
- part | offs | some_int |               some_text               | some_date  |        some_time         
-------+------+----------+---------------------------------------+------------+--------------------------
-    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
-    0 |    1 |       61 | It's some text, that is for number 61 | 01-01-2015 | Thu Jan 01 00:01:01 2015
-(2 rows)
-
-EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0;
-                       QUERY PLAN                        
+SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0');
+                    explain_invariant                    
 ---------------------------------------------------------
  Foreign Scan on kafka_test_part (actual rows=2 loops=1)
    Filter: ((offs <= $0) AND (part = 0))
@@ -232,14 +241,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_p
      ->  Result (actual rows=1 loops=1)
 (6 rows)
 
-SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1);
- part | offs | some_int |               some_text               | some_date  |        some_time         
-------+------+----------+---------------------------------------+------------+--------------------------
-    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
-(1 row)
-
-EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1);
-                       QUERY PLAN                        
+SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1)');
+                    explain_invariant                    
 ---------------------------------------------------------
  Foreign Scan on kafka_test_part (actual rows=1 loops=1)
    Filter: ((part < $0) AND (offs = 0))
@@ -249,15 +252,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_p
      ->  Result (actual rows=1 loops=1)
 (6 rows)
 
-SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1);
- part | offs | some_int |               some_text               | some_date  |        some_time         
-------+------+----------+---------------------------------------+------------+--------------------------
-    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
-    1 |    0 |        1 | It's some text, that is for number 1  | 01-01-2015 | Thu Jan 01 00:00:01 2015
-(2 rows)
-
-EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1);
-                       QUERY PLAN                        
+SELECT explain_invariant('SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1)');
+                    explain_invariant                    
 ---------------------------------------------------------
  Foreign Scan on kafka_test_part (actual rows=2 loops=1)
    Filter: ((part <= $0) AND (offs = 0))

--- a/test/expected/kafka_test.out
+++ b/test/expected/kafka_test.out
@@ -37,6 +37,15 @@ EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE part=1 AND some_int = 3 
  Foreign Scan on kafka_test_part
    Filter: ((offs > 4) AND (offs > 10) AND (offs < 100) AND (part = 1) AND (some_int = 3))
    Kafka topic: contrib_regress4
+   scanning: PARTITION = 1 AND OFFSET >= 11 AND OFFSET <= 99
+(4 rows)
+
+EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE part=1 AND some_int = 3 AND offs > 4 AND offs > 10 AND offs <= 100;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on kafka_test_part
+   Filter: ((offs > 4) AND (offs > 10) AND (offs <= 100) AND (part = 1) AND (some_int = 3))
+   Kafka topic: contrib_regress4
    scanning: PARTITION = 1 AND OFFSET >= 11 AND OFFSET <= 100
 (4 rows)
 
@@ -152,6 +161,112 @@ EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE ((part = 1 or part = 2) 
    scanning: PARTITION = 5 AND OFFSET = 10
    scanning: PARTITION = 5 AND OFFSET = 12
 (8 rows)
+
+-- check parameterized queries
+SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0;
+ part | offs | some_int |               some_text               | some_date  |        some_time         
+------+------+----------+---------------------------------------+------------+--------------------------
+    0 |    1 |       61 | It's some text, that is for number 61 | 01-01-2015 | Thu Jan 01 00:01:01 2015
+(1 row)
+
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on kafka_test_part (actual rows=1 loops=1)
+   Filter: ((offs = $0) AND (part = 0))
+   Kafka topic: contrib_regress4
+   scanning: PARTITION 0 AND OFFSET >= 1 AND OFFSET <= 1
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+(6 rows)
+
+SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1);
+ part | offs | some_int |              some_text               | some_date  |        some_time         
+------+------+----------+--------------------------------------+------------+--------------------------
+    1 |    0 |        1 | It's some text, that is for number 1 | 01-01-2015 | Thu Jan 01 00:00:01 2015
+(1 row)
+
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1);
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on kafka_test_part (actual rows=1 loops=1)
+   Filter: ((offs = 0) AND (part = $0))
+   Kafka topic: contrib_regress4
+   scanning: PARTITION 1 AND OFFSET >= 0 AND OFFSET <= 0
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+(6 rows)
+
+SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0;
+ part | offs | some_int |               some_text               | some_date  |        some_time         
+------+------+----------+---------------------------------------+------------+--------------------------
+    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
+(1 row)
+
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on kafka_test_part (actual rows=1 loops=1)
+   Filter: ((offs < $0) AND (part = 0))
+   Kafka topic: contrib_regress4
+   scanning: PARTITION 0 AND OFFSET >= 0 AND OFFSET <= 0
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+(6 rows)
+
+SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0;
+ part | offs | some_int |               some_text               | some_date  |        some_time         
+------+------+----------+---------------------------------------+------------+--------------------------
+    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
+    0 |    1 |       61 | It's some text, that is for number 61 | 01-01-2015 | Thu Jan 01 00:01:01 2015
+(2 rows)
+
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on kafka_test_part (actual rows=2 loops=1)
+   Filter: ((offs <= $0) AND (part = 0))
+   Kafka topic: contrib_regress4
+   scanning: PARTITION 0 AND OFFSET >= 0 AND OFFSET <= 1
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+(6 rows)
+
+SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1);
+ part | offs | some_int |               some_text               | some_date  |        some_time         
+------+------+----------+---------------------------------------+------------+--------------------------
+    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
+(1 row)
+
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1);
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on kafka_test_part (actual rows=1 loops=1)
+   Filter: ((part < $0) AND (offs = 0))
+   Kafka topic: contrib_regress4
+   scanning: PARTITION 0 AND OFFSET >= 0 AND OFFSET <= 0
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+(6 rows)
+
+SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1);
+ part | offs | some_int |               some_text               | some_date  |        some_time         
+------+------+----------+---------------------------------------+------------+--------------------------
+    0 |    0 |       21 | It's some text, that is for number 21 | 01-01-2015 | Thu Jan 01 00:00:21 2015
+    1 |    0 |        1 | It's some text, that is for number 1  | 01-01-2015 | Thu Jan 01 00:00:01 2015
+(2 rows)
+
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1);
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on kafka_test_part (actual rows=2 loops=1)
+   Filter: ((part <= $0) AND (offs = 0))
+   Kafka topic: contrib_regress4
+   scanning: PARTITION 0 AND OFFSET >= 0 AND OFFSET <= 0
+   scanning: PARTITION 1 AND OFFSET >= 0 AND OFFSET <= 0
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+(7 rows)
 
 -- run some memload
 select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;

--- a/test/sql/kafka_test.sql
+++ b/test/sql/kafka_test.sql
@@ -27,6 +27,7 @@ SERVER kafka_server OPTIONS
 -- check that we parse the queries right or error out if needed
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE offs = 1 AND part = 0;
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE part=1 AND some_int = 3 AND offs > 4 AND offs > 10 AND offs < 100;
+EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE part=1 AND some_int = 3 AND offs > 4 AND offs > 10 AND offs <= 100;
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE (part,offs)=(1,1) OR (part,offs)=(2,1);
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE (part,offs)=(1,1) OR (part,offs)=(1,2);
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE (part,offs)=(1,1) OR (part,offs)=(2,2);
@@ -38,6 +39,20 @@ EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE offs > 5 AND part = 1 ;
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE  5 < offs AND 1 = part ;
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE ((part = 1 or part = 2) and offs = 3) OR (part = 4 and offs=7);
 EXPLAIN (COSTS OFF) SELECT * FROM kafka_test_part WHERE ((part = 1 or part = 2) and offs = 3) OR ((part = 4 and offs=7 ) or ( part = 5 and (offs = 10 or offs=12)) );
+
+-- check parameterized queries
+SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0;
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = (SELECT 1) AND part = 0;
+SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1);
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1);
+SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0;
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs < (SELECT 1) AND part = 0;
+SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0;
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs <= (SELECT 1) AND part = 0;
+SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1);
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part < (SELECT 1);
+SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1);
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) SELECT * FROM kafka_test_part WHERE offs = 0 AND part <= (SELECT 1);
 
 -- run some memload
 select count(*) from (select json_agg(s) from generate_series(1, 1000000) s) a;


### PR DESCRIPTION
The original idea was to increase test coverage as it only amounted in about 74% at the start. But as new cases were tested some new bugs were discovered and the whole pull request could get too big (this is why #24 where proposed as separate PR). So I'm going to stop here and propose further fixes as separate PRs. What this PR contains:
* fix expression evaluation for `SELECT` queries with `part` and `offs` attributes. It turned out that expressions like `part < const` were treated as `part <= const` and therefore extra partition where scanned. It didn't affect the result as all rows from the last partition were filtered out by postgres anyway, but it produced extra traffic.
* fix assertion failures when use parameterised queries:
```
SELECT * FROM kafka_test_part WHERE offs = 0 AND part = (SELECT 1)
```
* fix travis script in order to be used in forks (replaced absolute path with relative one in `after_failure` section).
* added coverage tests for importing/exporting timestamptz, composite types and jsonb when using json format in Kafka.