### PR TITLE
Add ANALYZE support

### DIFF
--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -244,7 +244,7 @@ typedef struct KafkaFdwModifyState
 
 } KafkaFdwModifyState;
 /* connection.c */
-void KafkaFdwGetConnection(KafkaFdwExecutionState *festate, char errstr[KAFKA_MAX_ERR_MSG]);
+void KafkaFdwGetConnection(KafkaFdwExecutionState *festate);
 void kafkaCloseConnection(KafkaFdwExecutionState *festate);
 
 /* option.c */

--- a/src/parser.c
+++ b/src/parser.c
@@ -487,7 +487,7 @@ KafkaReadAttributesJson(char *msg, int msg_len, KafkaFdwExecutionState *festate,
 {
     ListCell *    cur;
     HTAB *        json_hash;
-    int           fieldno     = 0;
+    volatile int  fieldno     = 0;
     int           num_ent     = 0;
     bool          ignore_junk = festate->kafka_options.ignore_junk;
     MemoryContext ccxt        = CurrentMemoryContext;

--- a/src/planning.c
+++ b/src/planning.c
@@ -10,7 +10,8 @@
 void
 KafkaEstimateSize(PlannerInfo *root, RelOptInfo *baserel, KafkaFdwPlanState *fdw_private)
 {
-    double nrows, nbatches = 0;
+    double nrows = 0,
+           nbatches = 0;
     int    npart = 0;
 
     ListCell *    lc;

--- a/test/expected/analyze_test.out
+++ b/test/expected/analyze_test.out
@@ -1,0 +1,75 @@
+\i test/sql/setup.inc
+\set ECHO none
+-- test ANALYZE
+CREATE FOREIGN TABLE kafka_analyze_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json', batch_size '30', buffer_delay '500');
+-- set default costs so that local settings won't affect the test
+SET seq_page_cost     = 1.0;
+SET cpu_tuple_cost    = 0.01;
+SET cpu_operator_cost = 0.0025;
+SET max_parallel_workers_per_gather = 0;
+-- without statistics
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+   Filter: (some_int < 50)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+   Filter: (some_int < 500)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+   Filter: (some_int > 50000)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+-- with statistics
+ANALYZE kafka_analyze_json;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..101.36 rows=10 width=0)
+   Filter: (some_int < 50)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..110.87 rows=80 width=0)
+   Filter: (some_int < 500)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..12982.43 rows=94840 width=0)
+   Filter: (some_int > 50000)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+

--- a/test/expected/analyze_test_1.out
+++ b/test/expected/analyze_test_1.out
@@ -1,0 +1,76 @@
+\i test/sql/setup.inc
+\set ECHO none
+-- test ANALYZE
+CREATE FOREIGN TABLE kafka_analyze_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json', batch_size '30', buffer_delay '500');
+-- set default costs so that local settings won't affect the test
+SET seq_page_cost     = 1.0;
+SET cpu_tuple_cost    = 0.01;
+SET cpu_operator_cost = 0.0025;
+SET max_parallel_workers_per_gather = 0;
+ERROR:  unrecognized configuration parameter "max_parallel_workers_per_gather"
+-- without statistics
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+   Filter: (some_int < 50)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+   Filter: (some_int < 500)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+   Filter: (some_int > 50000)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+-- with statistics
+ANALYZE kafka_analyze_json;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..101.36 rows=10 width=0)
+   Filter: (some_int < 50)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..110.87 rows=80 width=0)
+   Filter: (some_int < 500)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on kafka_analyze_json  (cost=100.00..12982.43 rows=94840 width=0)
+   Filter: (some_int > 50000)
+   Kafka topic: contrib_regress_json
+   scanning: PARTITION >= 0 AND OFFSET >= 0
+(4 rows)
+

--- a/test/sql/analyze_test.sql
+++ b/test/sql/analyze_test.sql
@@ -1,0 +1,27 @@
+\i test/sql/setup.inc
+
+-- test ANALYZE
+CREATE FOREIGN TABLE kafka_analyze_json (
+    part int OPTIONS (partition 'true'),
+    offs bigint OPTIONS (offset 'true'),
+    some_int int OPTIONS (json 'int_val'),
+    some_text text OPTIONS (json 'text_val'),
+    some_date date OPTIONS (json 'date_val'),
+    some_time timestamp OPTIONS (json 'time_val')
+)
+SERVER kafka_server OPTIONS
+    (format 'json', topic 'contrib_regress_json', batch_size '30', buffer_delay '500');
+-- set default costs so that local settings won't affect the test
+SET seq_page_cost     = 1.0;
+SET cpu_tuple_cost    = 0.01;
+SET cpu_operator_cost = 0.0025;
+SET max_parallel_workers_per_gather = 0;
+-- without statistics
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
+-- with statistics
+ANALYZE kafka_analyze_json;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
+EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;

--- a/test/sql/kafka_test.sql
+++ b/test/sql/kafka_test.sql
@@ -125,3 +125,4 @@ SELECT COUNT(*) FROM kafka_test_part WHERE (part = 1 AND offs BETWEEN 1 AND 2) O
 PREPARE kafka_test(int,bigint,bigint, int,bigint,bigint) AS SELECT COUNT(*) FROM kafka_test_part WHERE (part = $1 AND offs BETWEEN $2 AND $3) OR ((part = $4 AND offs BETWEEN $5 AND $6) );
 EXPLAIN (COSTS OFF) EXECUTE kafka_test(1,100,200,1,500,600);
 EXPLAIN (COSTS OFF) EXECUTE kafka_test(1,1,2,1,5,6);
+


### PR DESCRIPTION
This commit adds kafkaAnalyzeForeignTable() handler which enables ANALYZE support. It also contains kafkaAcquireSampleRowsFunc() function which is needed for PostgreSQL machinery to produce statistical information for column data (histogram, most common values, etc). Some basic tests added as well.