### PR TITLE
Fix occasional 'Failed to stop consuming partition' error

### DIFF
--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -630,7 +630,7 @@ kafkaIterateForeignScan(ForeignScanState *node)
         }
 
         /* allocate partitions array in query-lifespan context */
-        oldcontext = MemoryContextSwitchTo(econtext->ecxt_per_query_memory);
+        oldcontext = MemoryContextSwitchTo(TopTransactionContext);
         KafkaFlattenScanlist(festate->scanop_list,
                              festate->partition_list,
                              kafka_options->batch_size,


### PR DESCRIPTION
This PR should fix #28. I believe the problem is that `KafkaScanPData` struct is allocated in per-tuple memory context (see `ForeignNext()`) and sometimes get clobbered by subsequent iterations. This patch fixes that by allocation struct in per-query context. Also I removed redundant context switch for expressions evaluation since it is already per-tuple context.