### PR TITLE
Add postgres 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,13 @@ matrix:
         install:
           - export PGPORT=5433
           - sudo make install
+      - env: postgres=11
+        install:
+          - sudo apt-get remove -y postgresql-9.2
+          - sudo apt-get install postgresql-11 postgresql-client-11 postgresql-server-dev-11
+          - export PGPORT=5433
+          - sudo -u postgres psql  -c "create user travis with superuser";
+          - sudo make install
 
     allow_failures:
       - env: postgres=9.4

--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -183,7 +183,6 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
 {
     KafkaFdwPlanState *fdw_private = (KafkaFdwPlanState *) baserel->fdw_private;
     Cost               startup_cost, total_cost, run_cost;
-    Relation           relation;
     Path *             foreign_path;
     int                num_workers;
 
@@ -195,18 +194,9 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
     num_workers = 0;
 #endif
 
-    relation = relation_open(foreigntableid, AccessShareLock);
-
     /* Estimate costs */
     KafkaEstimateCosts(root, baserel, fdw_private, &startup_cost, &total_cost, &run_cost);
 
-    relation_close(relation, AccessShareLock);
-
-    /*
-     * Create a ForeignPath node and add it as only possible path.  We use the
-     * fdw_private list of the path to carry the convert_selectively option;
-     * it will be propagated into the fdw_private list of the Plan node.
-     */
     foreign_path = (Path *)
         kafka_create_foreignscan_path(root,
                                       baserel,

--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -2,6 +2,7 @@
 #include "compatibility.h"
 #include "parser/parsetree.h"
 #include "storage/spin.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
@@ -9,6 +10,13 @@ PG_MODULE_MAGIC;
 
 #define MAX(_a, _b) ((_a > _b) ? _a : _b)
 #define STEP_FACTOR 20
+
+double kafka_tuple_cost = 0.2f;
+
+/*
+ * Module load callback
+ */
+void   _PG_init(void);
 
 /*
  * FDW callback routines
@@ -79,6 +87,29 @@ static void kafkaInitializeWorkerForeignScan(ForeignScanState *node, shm_toc *to
 static void kafkaShutdownForeignScan(ForeignScanState *node);
 static void kafkaGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 #endif
+
+
+/*
+ * Module load callback
+ */
+void
+_PG_init(void)
+{
+	/* Define custom GUC variables. */
+	DefineCustomRealVariable("kafka_fdw.tuple_cost",
+							 "Kafka tuple cost.",
+							 "Valid range is 0.0 .. 1.0.",
+							 &kafka_tuple_cost,
+							 0.2,
+							 0.0,
+							 1.0,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+}
+
 
 /*
  * Foreign-data wrapper handler function: return a struct with pointers
@@ -153,7 +184,7 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
     KafkaFdwPlanState *fdw_private = (KafkaFdwPlanState *) baserel->fdw_private;
     Cost               startup_cost, total_cost, run_cost;
     Relation           relation;
-    ForeignPath *      foreign_path;
+    Path *             foreign_path;
     int                num_workers;
 
     DEBUGLOG("%s", __func__);
@@ -161,7 +192,7 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
 #ifdef DO_PARALLEL
     num_workers = Min(fdw_private->npart - 1, max_parallel_workers_per_gather);
 #else
-    num_workers                         = 0;
+    num_workers = 0;
 #endif
 
     relation = relation_open(foreigntableid, AccessShareLock);
@@ -170,33 +201,64 @@ kafkaGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
     KafkaEstimateCosts(root, baserel, fdw_private, &startup_cost, &total_cost, &run_cost);
 
     relation_close(relation, AccessShareLock);
+
     /*
      * Create a ForeignPath node and add it as only possible path.  We use the
      * fdw_private list of the path to carry the convert_selectively option;
      * it will be propagated into the fdw_private list of the Plan node.
      */
-
-    foreign_path = kafka_create_foreignscan_path(root,
-                                                 baserel,
-                                                 NULL, /* default pathtarget */
-                                                 baserel->rows,
-                                                 startup_cost,
-                                                 total_cost,
-                                                 NIL,  /* no pathkeys */
-                                                 NULL, /* no outer rel either */
-                                                 NULL, /* no extra plan */
-                                                 NIL);
+    foreign_path = (Path *)
+        kafka_create_foreignscan_path(root,
+                                      baserel,
+                                      NULL, /* default pathtarget */
+                                      baserel->rows,
+                                      startup_cost,
+                                      total_cost,
+                                      NIL,  /* no pathkeys */
+                                      NULL, /* no outer rel either */
+                                      NULL, /* no extra plan */
+                                      NIL);
 #ifdef DO_PARALLEL
     /* Cannot add parameterized path as partial path */
     if (num_workers > 0 && baserel->consider_parallel)
     {
-        KafkaSetParallelPath((Path *) foreign_path, num_workers, startup_cost, total_cost, run_cost);
-        add_partial_path(baserel, (Path *) foreign_path);
+        Path *partial_path;
+
+        /* Create partial path that will be wrapped in gather node later */
+        partial_path = (Path *)
+            kafka_create_foreignscan_path(root,
+                                          baserel,
+                                          NULL, /* default pathtarget */
+                                          baserel->rows,
+                                          startup_cost,
+                                          total_cost,
+                                          NIL,  /* no pathkeys */
+                                          NULL, /* no outer rel either */
+                                          NULL, /* no extra plan */
+                                          NIL);
+        KafkaSetParallelPath((Path *) partial_path, num_workers, startup_cost, total_cost, run_cost);
+        add_partial_path(baserel, (Path *) partial_path);
+
+        /*
+         * Up until postgres 11 we could just return here and have partial path
+         * be choosen. Since 11 it's not possible as the gather node generation
+         * was moved to the later stage and we need at least some non-partial
+         * path added in case to proceed.
+         */
+#if PG_VERSION_NUM < 110000
         return;
+#else
+        /*
+         * If there is no statistics then just ignore foreign path by making
+         * its cost too big.
+         */
+        if (!baserel->tuples)
+            foreign_path->total_cost += disable_cost;
+#endif
     }
 #endif
 
-    add_path(baserel, (Path *) foreign_path);
+    add_path(baserel, foreign_path);
 }
 
 /*
@@ -383,7 +445,6 @@ static KafkaFdwExecutionState *
 makeKafkaExecutionState(Relation relation, KafkaOptions *kafka_options, ParseOptions *parse_options)
 {
     KafkaFdwExecutionState *festate;
-    Form_pg_attribute *     attr;
     AttrNumber              num_phys_attrs;
     FmgrInfo *              in_functions;
     Oid *                   typioparams;
@@ -416,7 +477,6 @@ makeKafkaExecutionState(Relation relation, KafkaOptions *kafka_options, ParseOpt
         initStringInfo(&festate->junk_buf);
 
     tupDesc        = RelationGetDescr(relation);
-    attr           = tupDesc->attrs;
     num_phys_attrs = tupDesc->natts;
 
     /* allocate enough space for fields */
@@ -442,20 +502,22 @@ makeKafkaExecutionState(Relation relation, KafkaOptions *kafka_options, ParseOpt
 
     for (attnum = 1; attnum <= num_phys_attrs; attnum++)
     {
+        FormData_pg_attribute *attr = TupleDescAttr(tupDesc, attnum - 1);
+
         /* We don't need info for dropped attributes */
-        if (attr[attnum - 1]->attisdropped)
+        if (attr->attisdropped)
             continue;
 
         attnums = lappend_int(attnums, attnum);
 
         /* Fetch the input function and typioparam info */
-        getTypeInputInfo(attr[attnum - 1]->atttypid, &in_func_oid, &typioparams[attnum - 1]);
+        getTypeInputInfo(attr->atttypid, &in_func_oid, &typioparams[attnum - 1]);
         fmgr_info(in_func_oid, &in_functions[attnum - 1]);
 
         if (parse_options->format == JSON)
         {
-            festate->attnames[attnum - 1] = getJsonAttname(attr[attnum - 1], &festate->attname_buf);
-            if (type_is_array(attr[attnum - 1]->atttypid))
+            festate->attnames[attnum - 1] = getJsonAttname(attr, &festate->attname_buf);
+            if (type_is_array(attr->atttypid))
                 festate->attisarray = bms_add_member(festate->attisarray, attnum - 1);
         }
     }
@@ -777,7 +839,6 @@ ReadKafkaMessage(Relation                rel,
                  bool **                 outnulls)
 {
     TupleDesc          tupDesc       = RelationGetDescr(rel);
-    Form_pg_attribute *attr          = tupDesc->attrs;
     int                num_attrs     = list_length(festate->attnumlist);
     volatile bool      catched_error = false;
 
@@ -846,6 +907,7 @@ ReadKafkaMessage(Relation                rel,
         int   attnum = lfirst_int(cur);
         int   m      = attnum - 1;
         char *string;
+        Form_pg_attribute attr = TupleDescAttr(tupDesc, m);
 
         if (attnum == kafka_options->junk_attnum || attnum == kafka_options->junk_error_attnum)
         {
@@ -887,7 +949,7 @@ ReadKafkaMessage(Relation                rel,
             PG_TRY();
             {
                 values[m] =
-                  InputFunctionCall(&festate->in_functions[m], string, festate->typioparams[m], attr[m]->atttypmod);
+                  InputFunctionCall(&festate->in_functions[m], string, festate->typioparams[m], attr->atttypmod);
                 nulls[m] = false;
             }
             PG_CATCH();
@@ -914,7 +976,7 @@ ReadKafkaMessage(Relation                rel,
             continue;
         }
 
-        values[m] = InputFunctionCall(&festate->in_functions[m], string, festate->typioparams[m], attr[m]->atttypmod);
+        values[m] = InputFunctionCall(&festate->in_functions[m], string, festate->typioparams[m], attr->atttypmod);
         nulls[m]  = false;
     }
 
@@ -1005,7 +1067,7 @@ next_work(KafkaScanPData *scan_p, KafkaScanDataDesc *scand)
 #ifdef DO_PARALLEL
     next = pg_atomic_fetch_add_u32(&scand->next_scanp, 1);
 #else
-    next                                = scand->next_scanp++;
+    next = scand->next_scanp++;
 #endif
 
     if (next >= scan_p->len)
@@ -1123,7 +1185,7 @@ kafkaPlanForeignModify(PlannerInfo *root, ModifyTable *plan, Index resultRelatio
 
     for (attnum = 1; attnum <= tupdesc->natts; attnum++)
     {
-        Form_pg_attribute attr = tupdesc->attrs[attnum - 1];
+        Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
 
         if (!attr->attisdropped)
             targetAttrs = lappend_int(targetAttrs, attnum);
@@ -1237,7 +1299,7 @@ kafkaBeginForeignModify(ModifyTableState *mtstate,
         else
         {
 
-            Form_pg_attribute attr = RelationGetDescr(rel)->attrs[attnum - 1];
+            Form_pg_attribute attr = TupleDescAttr(RelationGetDescr(rel), attnum - 1);
             Assert(!attr->attisdropped);
 
             getTypeOutputInfo(attr->atttypid, &typefnoid, &isvarlena);

--- a/src/option.c
+++ b/src/option.c
@@ -427,7 +427,7 @@ get_kafka_fdw_attribute_options(Oid relid, KafkaOptions *kafka_options)
     /* Retrieve FDW options for all user-defined attributes. */
     for (attnum = 1; attnum <= natts; attnum++)
     {
-        Form_pg_attribute attr = tupleDesc->attrs[attnum - 1];
+        Form_pg_attribute attr = TupleDescAttr(tupleDesc, attnum - 1);
         List *            options;
         ListCell *        lc;
         kafka_options->num_parse_col++;

--- a/src/parser.c
+++ b/src/parser.c
@@ -906,15 +906,16 @@ composite_to_json(Datum composite, StringInfo result, bool use_line_feeds)
         char *           attname;
         JsonTypeCategory tcategory;
         Oid              outfuncoid;
+        Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
 
-        if (tupdesc->attrs[i]->attisdropped)
+        if (attr->attisdropped)
             continue;
 
         if (needsep)
             appendStringInfoString(result, sep);
         needsep = true;
 
-        attname = NameStr(tupdesc->attrs[i]->attname);
+        attname = NameStr(attr->attname);
         escape_json(result, attname);
         appendStringInfoChar(result, ':');
 
@@ -926,7 +927,7 @@ composite_to_json(Datum composite, StringInfo result, bool use_line_feeds)
             outfuncoid = InvalidOid;
         }
         else
-            json_categorize_type(tupdesc->attrs[i]->atttypid, &tcategory, &outfuncoid);
+            json_categorize_type(attr->atttypid, &tcategory, &outfuncoid);
 
         datum_to_json(val, isnull, result, tcategory, outfuncoid, false);
     }

--- a/src/planning.c
+++ b/src/planning.c
@@ -1,5 +1,9 @@
 #include "kafka_fdw.h"
 
+
+extern double kafka_tuple_cost;
+
+
 /*
  * Estimate size of a foreign table.
  *
@@ -47,7 +51,7 @@ KafkaEstimateSize(PlannerInfo *root, RelOptInfo *baserel, KafkaFdwPlanState *fdw
                                    0,
                                    JOIN_INNER,
                                    NULL);
-        npart = 1;  /* can't get it from statistics */
+        npart = kafka_options->num_partitions;  /* can't get it from statistics */
     }
     /* No statistics, try to guess */
     else
@@ -104,7 +108,7 @@ KafkaEstimateCosts(PlannerInfo *      root,
     *run_cost = seq_page_cost * nbatches;
 
     *startup_cost = 100;
-    cpu_per_tuple = cpu_tuple_cost * 10 + baserel->baserestrictcost.per_tuple;
+    cpu_per_tuple = kafka_tuple_cost + baserel->baserestrictcost.per_tuple;
     *run_cost += cpu_per_tuple * ntuples;
     *total_cost = *startup_cost + *run_cost;
     DEBUGLOG("startup cost: %f, total_cost: %f, cpu_per_tuple: %f", *startup_cost, *total_cost, cpu_per_tuple);

--- a/test/expected/analyze_test.out
+++ b/test/expected/analyze_test.out
@@ -20,7 +20,7 @@ SET max_parallel_workers_per_gather = 0;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..23683.33 rows=100000 width=0)
    Filter: (some_int < 50)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -29,7 +29,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..23683.33 rows=100000 width=0)
    Filter: (some_int < 500)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -38,7 +38,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..23683.33 rows=100000 width=0)
    Filter: (some_int > 50000)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -49,7 +49,7 @@ ANALYZE kafka_analyze_json;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..101.36 rows=10 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..102.36 rows=10 width=0)
    Filter: (some_int < 50)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -58,7 +58,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..110.87 rows=80 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..118.87 rows=80 width=0)
    Filter: (some_int < 500)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -67,7 +67,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..12982.43 rows=94840 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..22466.43 rows=94840 width=0)
    Filter: (some_int > 50000)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0

--- a/test/expected/analyze_test_1.out
+++ b/test/expected/analyze_test_1.out
@@ -21,7 +21,7 @@ ERROR:  unrecognized configuration parameter "max_parallel_workers_per_gather"
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..23683.33 rows=100000 width=0)
    Filter: (some_int < 50)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -30,7 +30,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..23683.33 rows=100000 width=0)
    Filter: (some_int < 500)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -39,7 +39,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..13683.33 rows=100000 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..23683.33 rows=100000 width=0)
    Filter: (some_int > 50000)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -50,7 +50,7 @@ ANALYZE kafka_analyze_json;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..101.36 rows=10 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..102.36 rows=10 width=0)
    Filter: (some_int < 50)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -59,7 +59,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 50;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..110.87 rows=80 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..118.87 rows=80 width=0)
    Filter: (some_int < 500)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0
@@ -68,7 +68,7 @@ EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int < 500;
 EXPLAIN SELECT FROM kafka_analyze_json WHERE some_int > 50000;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Foreign Scan on kafka_analyze_json  (cost=100.00..12982.43 rows=94840 width=0)
+ Foreign Scan on kafka_analyze_json  (cost=100.00..22466.43 rows=94840 width=0)
    Filter: (some_int > 50000)
    Kafka topic: contrib_regress_json
    scanning: PARTITION >= 0 AND OFFSET >= 0

--- a/test/expected/kafka_test.out
+++ b/test/expected/kafka_test.out
@@ -25,8 +25,8 @@ DECLARE
 BEGIN
     FOR rec IN SELECT * FROM explain(query) as e(t text)
     LOOP
-        IF position('Planning time' in rec.t) > 0 OR
-           position('Execution time' in rec.t) > 0
+        IF position('planning time' in lower(rec.t)) > 0 OR
+           position('execution time' in lower(rec.t)) > 0
         THEN
             CONTINUE;
         END IF;

--- a/test/sql/kafka_test.sql
+++ b/test/sql/kafka_test.sql
@@ -26,8 +26,8 @@ DECLARE
 BEGIN
     FOR rec IN SELECT * FROM explain(query) as e(t text)
     LOOP
-        IF position('Planning time' in rec.t) > 0 OR
-           position('Execution time' in rec.t) > 0
+        IF position('planning time' in lower(rec.t)) > 0 OR
+           position('execution time' in lower(rec.t)) > 0
         THEN
             CONTINUE;
         END IF;


### PR DESCRIPTION
Fix incompatibility issues and travis-ci script. Particularly:
* use macros to access tuple descriptor attributes instead of directly picking them from struct;
* change `kafkaGetForeignPaths` behavior for pg11. The thing is that in pg11 the generation of gather nodes was moved to the later stage and now we need to provide at least some non-partial path (see comment) otherwise postgres will throw an error. (there are cases when `foreign_path` is created but not used. I decided not to do anything about it for the sake of code clarity and because of insignificance of impact to performance)
* add build for pg11 to the travis script.

I also added separate GUC variable `kafka_tuple_cost`. It only matters for postgres 11 and in the cases when statistics were collected. In that case both paths (gather and simple foreign scan) are added to the pathlist and their costs are being compared. For example:

```
# EXPLAIN SELECT * FROM kafka_analyze_json where offs < 50000;
                                          QUERY PLAN                                           
-----------------------------------------------------------------------------------------------
 Gather  (cost=1100.00..11043.93 rows=50155 width=69)
   Workers Planned: 2
   ->  Parallel Foreign Scan on kafka_analyze_json  (cost=100.00..5028.43 rows=20898 width=69)
         Filter: (offs < 50000)
         Kafka topic: contrib_regress_json
         scanning: PARTITION >= 0 AND OFFSET >= 0 AND OFFSET <= 49999
(6 rows)

# EXPLAIN SELECT * FROM kafka_analyze_json where offs < 20000;
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Foreign Scan on kafka_analyze_json  (cost=100.00..4853.93 rows=20158 width=69)
   Filter: (offs < 20000)
   Kafka topic: contrib_regress_json
   scanning: PARTITION >= 0 AND OFFSET >= 0 AND OFFSET <= 19999
(4 rows)
```

Should we generalize this for the older postgres versions too?