### PR TITLE
Refactor error handling in kafkaAcquireSampleRowsFunc()

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -106,8 +106,10 @@ KafkaFdwGetConnection(KafkaFdwExecutionState *festate)
 void
 kafkaCloseConnection(KafkaFdwExecutionState *festate)
 {
-    rd_kafka_topic_destroy(festate->kafka_topic_handle);
-    rd_kafka_destroy(festate->kafka_handle);
+    if (festate->kafka_topic_handle)
+        rd_kafka_topic_destroy(festate->kafka_topic_handle);
+    if (festate->kafka_handle)
+        rd_kafka_destroy(festate->kafka_handle);
     festate->kafka_topic_handle = NULL;
     festate->kafka_handle       = NULL;
 }


### PR DESCRIPTION
After code review I noticed that currently in `kafkaAcquireSampleRowsFunc()` cases are possible when connection stays open after errors are thrown (e.g. palloc throws ERROR). This PR fixes it.