### PR TITLE
kafka_fdw_get_watermarks: use bigint

### DIFF
--- a/kafka_fdw--0.0.1--0.0.2.sql
+++ b/kafka_fdw--0.0.1--0.0.2.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION kafka_get_watermarks(IN rel regclass,
 	OUT partition int,
-	OUT offset_low int,
-	OUT offset_high int)
+	OUT offset_low bigint,
+	OUT offset_high bigint)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;

--- a/sql/kafka_fdw.sql
+++ b/sql/kafka_fdw.sql
@@ -1,7 +1,7 @@
 CREATE TABLE kafka_fdw_offset_dump(
     tbloid oid,
     partition int,
-    "offset" int,
+    "offset" bigint,
     last_fetch timestamp DEFAULT statement_timestamp(),
     PRIMARY KEY(tbloid, partition)
 );
@@ -23,8 +23,8 @@ CREATE FOREIGN DATA WRAPPER kafka_fdw
 
 CREATE FUNCTION kafka_get_watermarks(IN rel regclass,
 	OUT partition int,
-	OUT offset_low int,
-	OUT offset_high int)
+	OUT offset_low bigint,
+	OUT offset_high bigint)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;


### PR DESCRIPTION
The C symbol returns int64_t for kafka watermarks (and so does rdkafka).
The function in postgres should therefore return bigint.