### PR TITLE
kafka_fdw_get_watermarks: use bigint (2nd take)

### DIFF
--- a/kafka_fdw--0.0.1--0.0.2.sql
+++ b/kafka_fdw--0.0.1--0.0.2.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION kafka_get_watermarks(IN rel regclass,
 	OUT partition int,
-	OUT offset_low int,
-	OUT offset_high int)
+	OUT offset_low bigint,
+	OUT offset_high bigint)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;

--- a/kafka_fdw--0.0.2--0.0.3.sql
+++ b/kafka_fdw--0.0.2--0.0.3.sql
@@ -1,7 +1,10 @@
-CREATE FUNCTION kafka_get_watermarks(IN rel regclass,
+DROP FUNCTION kafka_get_watermarks(IN regclass, OUT int, OUT int, OUT int);
+
+CREATE FUNCTION kafka_get_watermarks(
+    IN rel regclass,
 	OUT partition int,
-	OUT offset_low int,
-	OUT offset_high int)
+	OUT offset_low bigint,
+	OUT offset_high bigint)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;
@@ -15,3 +18,5 @@ BEGIN
     END IF;
 END
 $$;
+
+ALTER TABLE kafka_fdw_offset_dump ALTER COLUMN "offset" TYPE bigint;

--- a/kafka_fdw--0.0.2--0.0.3.sql
+++ b/kafka_fdw--0.0.2--0.0.3.sql
@@ -9,14 +9,4 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;
 
-DO $$
-DECLARE version_num INTEGER;
-BEGIN
-    SELECT current_setting('server_version_num') INTO STRICT version_num;
-    IF version_num > 90600 THEN
-        EXECUTE 'ALTER FUNCTION kafka_get_watermarks(regclass) PARALLEL SAFE';
-    END IF;
-END
-$$;
-
 ALTER TABLE kafka_fdw_offset_dump ALTER COLUMN "offset" TYPE bigint;

--- a/kafka_fdw.control
+++ b/kafka_fdw.control
@@ -1,5 +1,5 @@
 # kafka FDW
 comment = 'kafka Foreign Data Wrapper for CSV formated messages'
-default_version = '0.0.2'
+default_version = '0.0.3'
 module_pathname = '$libdir/kafka_fdw'
 relocatable = true

--- a/sql/kafka_fdw.sql
+++ b/sql/kafka_fdw.sql
@@ -28,13 +28,3 @@ CREATE FUNCTION kafka_get_watermarks(IN rel regclass,
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;
-
-DO $$
-DECLARE version_num INTEGER;
-BEGIN
-    SELECT current_setting('server_version_num') INTO STRICT version_num;
-    IF version_num > 90600 THEN
-        EXECUTE 'ALTER FUNCTION kafka_get_watermarks(regclass) PARALLEL SAFE';
-    END IF;
-END
-$$;

--- a/sql/kafka_fdw.sql
+++ b/sql/kafka_fdw.sql
@@ -1,7 +1,7 @@
 CREATE TABLE kafka_fdw_offset_dump(
     tbloid oid,
     partition int,
-    "offset" int,
+    "offset" bigint,
     last_fetch timestamp DEFAULT statement_timestamp(),
     PRIMARY KEY(tbloid, partition)
 );
@@ -23,8 +23,8 @@ CREATE FOREIGN DATA WRAPPER kafka_fdw
 
 CREATE FUNCTION kafka_get_watermarks(IN rel regclass,
 	OUT partition int,
-	OUT offset_low int,
-	OUT offset_high int)
+	OUT offset_low bigint,
+	OUT offset_high bigint)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'kafka_get_watermarks'
 LANGUAGE C STRICT;


### PR DESCRIPTION
Reworked version of PR #43. The function argument types changes were moved to a new update script, extension's version bumped. Notice that script drops the old version of the function and creates a new one. This is [the only way](https://www.postgresql.org/docs/14/sql-createfunction.html) to change the argument types. So if there are objects depending on this function (e.g. views), they have to be recreated.