### PR TITLE
custom librdkafka options

### DIFF
--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -150,6 +150,7 @@ typedef struct KafkaOptions
     bool  strict;            /* force strict parsing */
     bool  ignore_junk;       /* ignore junk data by setting it to null */
     int   num_parse_col;     /* number of parsable columns */
+    List *options;
 } KafkaOptions;
 
 typedef struct ParseOptions

--- a/src/option.c
+++ b/src/option.c
@@ -325,6 +325,9 @@ is_valid_option(const char *option, Oid context)
 {
     const struct KafkaFdwOption *opt;
 
+    if (option[0] == '#')
+        return true;
+
     for (opt = valid_options; opt->optname; opt++)
     {
         if (context == opt->optcontext && strcmp(opt->optname, option) == 0)
@@ -353,7 +356,12 @@ KafkaProcessKafkaOptions(Oid relid, KafkaOptions *kafka_options, List *options)
     {
         DefElem *def = (DefElem *) lfirst(option);
 
-        if (strcmp(def->defname, "topic") == 0)
+        if (def->defname[0] == '#')
+        {
+            kafka_options->options = lappend(kafka_options->options, def);
+        }
+
+        else if (strcmp(def->defname, "topic") == 0)
         {
             if (kafka_options->topic)
                 ereport(ERROR,


### PR DESCRIPTION
I use custom librdkafka options for kerberos authentification
```sql
CREATE SERVER sasl_plaintext FOREIGN DATA WRAPPER kafka_fdw OPTIONS (
    brokers 'localhost:9093',
    "#sasl.kerberos.keytab" '/etc/krb5.keytab',
    "#sasl.kerberos.kinit.cmd" 'kinit -V -R -t %{sasl.kerberos.keytab} -k %{sasl.kerberos.principal} || kinit -V -t %{sasl.kerberos.keytab} -k %{sasl.kerberos.principal}',
    "#sasl.kerberos.min.time.before.relogin" '1000',
    "#sasl.kerberos.principal" 'kafka/localhost',
    "#sasl.kerberos.service.name" 'kafka',
    "#security.protocol" 'sasl_plaintext'
);
```