### PR TITLE
Add PG 17 / 18 Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ OBJS         =  $(patsubst %.c,%.o,$(wildcard src/*.c))
 PG_CONFIG   ?= pg_config
 PG_CPPFLAGS  = -std=c99 -Wall -Wextra -Wno-unused-parameter
 
+PLATFORM 	 = $(shell uname -s)
+
+ifeq ($(PLATFORM),Darwin)
+PG_CPPFLAGS += -I/opt/homebrew/include
+endif
+
 ifndef NOINIT
 REGRESS_PREP = prep_kafka
 endif
@@ -28,11 +34,8 @@ ifeq ($(shell test $(VERSION_NUM) -lt 100000; echo $$?),0)
 REGRESS := $(filter-out parallel, $(REGRESS))
 endif
 
-
-PLATFORM 	 = $(shell uname -s)
-
 ifeq ($(PLATFORM),Darwin)
-SHLIB_LINK += -lrdkafka -lz -lpthread
+SHLIB_LINK += -lrdkafka -lz -lpthread -L/opt/homebrew/lib
 PG_LIBS += -lrdkafka -lz -lpthread
 else
 SHLIB_LINK += -lrdkafka -lz -lpthread -lrt

--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -40,7 +40,56 @@ ExecInitExprList(List *nodes, PlanState *parent)
     create_foreignscan_path signature has changed accros different pg versions
     kafka_create_foreignscan_path harmonizes it
 */
-#if PG_VERSION_NUM >= 90600
+#if PG_VERSION_NUM >= 180000
+/* PG18+: added disabled_nodes parameter and fdw_restrictinfo */
+#define kafka_create_foreignscan_path(planner_info,                                                                    \
+                                      reloptinfo,                                                                      \
+                                      pathtarget,                                                                      \
+                                      rows,                                                                            \
+                                      startup_cost,                                                                    \
+                                      total_cost,                                                                      \
+                                      pathkeys,                                                                        \
+                                      req_outer,                                                                       \
+                                      fdw_outerpath,                                                                   \
+                                      fdw_private)                                                                     \
+    (create_foreignscan_path(planner_info,                                                                             \
+                             reloptinfo,                                                                               \
+                             pathtarget,                                                                               \
+                             rows,                                                                                     \
+                             0, /* disabled_nodes */                                                                   \
+                             startup_cost,                                                                             \
+                             total_cost,                                                                               \
+                             pathkeys,                                                                                 \
+                             req_outer,                                                                                \
+                             fdw_outerpath,                                                                            \
+                             NIL, /* fdw_restrictinfo */                                                               \
+                             fdw_private))
+
+#elif PG_VERSION_NUM >= 170000
+/* PG17: added fdw_restrictinfo parameter */
+#define kafka_create_foreignscan_path(planner_info,                                                                    \
+                                      reloptinfo,                                                                      \
+                                      pathtarget,                                                                      \
+                                      rows,                                                                            \
+                                      startup_cost,                                                                    \
+                                      total_cost,                                                                      \
+                                      pathkeys,                                                                        \
+                                      req_outer,                                                                       \
+                                      fdw_outerpath,                                                                   \
+                                      fdw_private)                                                                     \
+    (create_foreignscan_path(planner_info,                                                                             \
+                             reloptinfo,                                                                               \
+                             pathtarget,                                                                               \
+                             rows,                                                                                     \
+                             startup_cost,                                                                             \
+                             total_cost,                                                                               \
+                             pathkeys,                                                                                 \
+                             req_outer,                                                                                \
+                             fdw_outerpath,                                                                            \
+                             NIL, /* fdw_restrictinfo */                                                               \
+                             fdw_private))
+
+#elif PG_VERSION_NUM >= 90600
 #define kafka_create_foreignscan_path(planner_info,                                                                    \
                                       reloptinfo,                                                                      \
                                       pathtarget,                                                                      \

--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -16,6 +16,10 @@
 #include "catalog/pg_foreign_table.h"
 #include "commands/defrem.h"
 #include "commands/explain.h"
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#include "commands/explain_format.h"
+#endif
 #include "commands/vacuum.h"
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"

--- a/src/utils.c
+++ b/src/utils.c
@@ -90,7 +90,9 @@ kafka_get_watermarks(PG_FUNCTION_ARGS)
             tuplestore_putvalues(tupstore, tupdesc, values, nulls);
         }
 
+#if PG_VERSION_NUM < 170000
         tuplestore_donestoring(tupstore);
+#endif
     }
     PG_CATCH();
     {


### PR DESCRIPTION
  - FDW Path API Evolution: Extended create_foreignscan_path wrapper to accommodate new parameters—fdw_restrictinfo (PG17) and disabled_nodes (PG18). Version-specific macro
   definitions pass appropriate defaults (NIL and 0 respectively) to satisfy the new signatures.
  - JSON Subsystem Refactoring: PG17 internalized JSON processing functions with modified signatures. Implemented compatibility wrappers for json_categorize_type (now
  requires boolean parameter) and datum_to_json (return type changed from void to Datum). Pre-17 versions retain original static implementations.
  - Lexer Initialization Contract Change: Adapted makeJsonLexContextCstringLen invocation to use stack-allocated JsonLexContext buffer for PG17+, replacing the previous
  heap-allocation model.
  - Tuplestore API Cleanup: Removed tuplestore_donestoring call for PG17+ where explicit finalization is no longer necessary.
  - Header Modularization: Added explicit includes for explain_state.h and explain_format.h in PG18, following the reorganization of explain infrastructure.
  - Type Qualifier Corrections: Updated save_json_start member to const char* matching PG17's stricter const-correctness requirements.
