### PR TITLE
High level consumer

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -69,6 +69,78 @@ KafkaFdwGetConnection(KafkaOptions *k_options,
     }
 }
 
+/*
+ * KafkaFdwGetConsumer
+ *
+ * Open a group-less high-level consumer for the scan path.  Unlike the legacy
+ * simple consumer (rd_kafka_consume_start/_batch/_stop) this drives consumption
+ * via rd_kafka_assign() + rd_kafka_consumer_poll().  We never subscribe and
+ * never commit offsets, so no consumer group is joined.
+ *
+ * librdkafka permits omitting group.id only when enable.auto.commit is
+ * explicitly set to false (KIP-289); otherwise rd_kafka_new() fails with
+ * "enable.auto.commit must be explicitly set to false when group.id is not
+ * configured".  On librdkafka versions that still require group.id even for
+ * assign(), set a fixed dummy group.id (e.g. "kafka_fdw") here in addition to
+ * enable.auto.commit=false - that still results in no group activity.
+ */
+void
+KafkaFdwGetConsumer(KafkaOptions *k_options,
+                    rd_kafka_t **kafka_handle,
+                    rd_kafka_topic_t **kafka_topic_handle)
+{
+    rd_kafka_conf_t *conf;
+    char             errstr[KAFKA_MAX_ERR_MSG];
+
+    if (k_options->brokers == NULL || k_options->topic == NULL)
+        elog(ERROR, "brokers and topic need to be set ");
+
+    conf = rd_kafka_conf_new();
+
+    if (rd_kafka_conf_set(conf, "bootstrap.servers", k_options->brokers, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        rd_kafka_conf_destroy(conf);
+        elog(ERROR, "%s", errstr);
+    }
+
+    /* required to run without a group.id (see function comment) */
+    if (rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        rd_kafka_conf_destroy(conf);
+        elog(ERROR, "%s", errstr);
+    }
+
+    /* emit an explicit PARTITION_EOF marker when a partition is exhausted */
+    if (rd_kafka_conf_set(conf, "enable.partition.eof", "true", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        rd_kafka_conf_destroy(conf);
+        elog(ERROR, "%s", errstr);
+    }
+
+    *kafka_handle = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, KAFKA_MAX_ERR_MSG);
+    if (*kafka_handle == NULL)
+    {
+        rd_kafka_conf_destroy(conf);
+        ereport(ERROR,
+                (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+                 errmsg_internal("kafka_fdw: Unable to connect to %s", k_options->brokers),
+                 errdetail("%s", errstr)));
+    }
+
+    /* redirect the handle's main queue so rd_kafka_consumer_poll() works */
+    rd_kafka_poll_set_consumer(*kafka_handle);
+
+    /*
+     * We still create a topic handle - it is only used for metadata lookups
+     * (getPartitionList); it is NOT used for the legacy consume API here.
+     */
+    *kafka_topic_handle = rd_kafka_topic_new(*kafka_handle, k_options->topic, NULL);
+    if (*kafka_topic_handle == NULL)
+        ereport(ERROR,
+                (errcode(ERRCODE_FDW_ERROR),
+                 errmsg_internal("kafka_fdw: Unable to create topic %s", k_options->topic)));
+}
+
 void
 kafkaCloseConnection(KafkaFdwExecutionState *festate)
 {

--- a/src/connection.c
+++ b/src/connection.c
@@ -77,13 +77,15 @@ KafkaFdwGetConnection(KafkaOptions *k_options,
  * via rd_kafka_assign() + rd_kafka_consumer_poll().  We never subscribe and
  * never commit offsets, so no consumer group is joined.
  *
- * librdkafka permits omitting group.id only when enable.auto.commit is
- * explicitly set to false (KIP-289); otherwise rd_kafka_new() fails with
- * "enable.auto.commit must be explicitly set to false when group.id is not
- * configured".  On librdkafka versions that still require group.id even for
- * assign(), set a fixed dummy group.id (e.g. "kafka_fdw") here in addition to
- * enable.auto.commit=false - that still results in no group activity.
+ * librdkafka requires a group.id to instantiate a consumer that uses
+ * rd_kafka_assign() - without it the assign call fails with
+ * "Local: Unknown group" (RD_KAFKA_RESP_ERR__UNKNOWN_GROUP).  We therefore
+ * configure a fixed group.id together with enable.auto.commit=false.  Because
+ * we only ever assign() (never subscribe()) and never commit offsets, no
+ * actual consumer group is joined: there is no rebalancing and no group
+ * coordinator traffic - the group.id is just a required configuration value.
  */
+#define KAFKA_FDW_GROUP_ID "kafka_fdw"
 void
 KafkaFdwGetConsumer(KafkaOptions *k_options,
                     rd_kafka_t **kafka_handle,
@@ -103,7 +105,17 @@ KafkaFdwGetConsumer(KafkaOptions *k_options,
         elog(ERROR, "%s", errstr);
     }
 
-    /* required to run without a group.id (see function comment) */
+    /*
+     * A group.id is required for rd_kafka_assign() (see function comment).
+     * Combined with enable.auto.commit=false and assign-only usage this stays
+     * effectively group-less: no rebalancing, no offset commits.
+     */
+    if (rd_kafka_conf_set(conf, "group.id", KAFKA_FDW_GROUP_ID, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        rd_kafka_conf_destroy(conf);
+        elog(ERROR, "%s", errstr);
+    }
+
     if (rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
         rd_kafka_conf_destroy(conf);

--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -865,6 +865,21 @@ kafkaIterateForeignScan(ForeignScanState *node)
                          errmsg_internal("kafka_fdw got an error %s when fetching a message from queue",
                                          rd_kafka_err2str(message->err))));
             }
+            /*
+             * Enforce the requested upper offset bound on the freshly polled
+             * message.  With the legacy batch consumer this was handled by the
+             * top-of-function check on messages still buffered from a previous
+             * rd_kafka_consume_batch().  Since we now poll a single message at a
+             * time that buffer is always drained, so the check would never fire
+             * and we would read the whole partition.  scan_p points at the
+             * current partition's scan item (set at the top of this loop).
+             */
+            else if (scan_p->offset_lim >= 0 && scan_p->offset_lim < message->offset)
+            {
+                DEBUGLOG("kafka_fdw has reached the end of requested offset in queue");
+                if (!kafkaNext(festate))
+                    return slot;
+            }
         }
     }
 

--- a/src/kafka_fdw.c
+++ b/src/kafka_fdw.c
@@ -578,10 +578,10 @@ kafkaBeginForeignScan(ForeignScanState *node, int eflags)
      * Init Kafka-related stuff
      */
 
-    /* Open connection if possible */
-    KafkaFdwGetConnection(&kafka_options,
-                          &festate->kafka_handle,
-                          &festate->kafka_topic_handle);
+    /* Open a group-less high-level consumer (assign + poll) for the scan */
+    KafkaFdwGetConsumer(&kafka_options,
+                        &festate->kafka_handle,
+                        &festate->kafka_topic_handle);
 
     festate->partition_list = getPartitionList(festate->kafka_handle,
                                                festate->kafka_topic_handle);
@@ -806,19 +806,29 @@ kafkaIterateForeignScan(ForeignScanState *node)
         scan_p = &festate->scan_data->data[festate->scan_data->cursor];
 
         DEBUGLOG("start consume");
-        festate->buffer_count = rd_kafka_consume_batch(festate->kafka_topic_handle,
-                                                       scan_p->partition,
-                                                       kafka_options->buffer_delay,
-                                                       festate->buffer,
-                                                       kafka_options->batch_size);
+        /*
+         * High-level consumer: poll a single message from the currently
+         * assigned partition.  rd_kafka_consumer_poll() returns NULL on
+         * timeout (no data within buffer_delay) or a message - which may also
+         * carry an error/EOF marker in message->err, handled below.  We reuse
+         * the existing buffer[]/buffer_count/buffer_cursor machinery with a
+         * batch of at most one.
+         */
+        {
+            rd_kafka_message_t *polled = rd_kafka_consumer_poll(festate->kafka_handle, kafka_options->buffer_delay);
+
+            if (polled == NULL)
+            {
+                festate->buffer_count = 0;
+            }
+            else
+            {
+                festate->buffer[0]    = polled;
+                festate->buffer_count = 1;
+            }
+        }
         DEBUGLOG("done consume %zd", festate->buffer_count);
         festate->buffer_cursor = 0;
-
-        if (festate->buffer_count == -1)
-            ereport(
-              ERROR,
-              (errcode(ERRCODE_FDW_ERROR),
-               errmsg_internal("kafka_fdw got an error fetching data %s", rd_kafka_err2str(rd_kafka_last_error()))));
 
         if (festate->buffer_count <= 0) /* no data within the poll timeout */
         {
@@ -1127,13 +1137,20 @@ kafkaStop(KafkaFdwExecutionState *festate)
 
     scan_p = &scan_data->data[scan_data->cursor];
 
-    if (rd_kafka_consume_stop(festate->kafka_topic_handle, scan_p->partition) == -1)
+    /*
+     * Stop consuming by clearing the assignment.  We always assign exactly one
+     * partition at a time, so unassigning all is equivalent to stopping the
+     * current partition.  Replaces the legacy rd_kafka_consume_stop().
+     */
     {
-        rd_kafka_resp_err_t err = rd_kafka_last_error();
-        ereport(ERROR,
-                (errcode(ERRCODE_FDW_ERROR),
-                 errmsg_internal(
-                   "kafka_fdw: Failed to stop consuming partition %d:  %s", scan_p->partition, rd_kafka_err2str(err))));
+        rd_kafka_resp_err_t err = rd_kafka_assign(festate->kafka_handle, NULL);
+
+        if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
+            ereport(ERROR,
+                    (errcode(ERRCODE_FDW_ERROR),
+                     errmsg_internal("kafka_fdw: Failed to stop consuming partition %d:  %s",
+                                     scan_p->partition,
+                                     rd_kafka_err2str(err))));
     }
 
     /* release unconsumed messages */
@@ -1187,13 +1204,28 @@ kafkaStart(KafkaFdwExecutionState *festate)
              low,
              festate->kafka_options.topic);
 
-    /* Start consuming */
-    if (rd_kafka_consume_start(festate->kafka_topic_handle, scan_p->partition, MAX(low, scan_p->offset)) == -1)
+    /*
+     * Start consuming the partition by assigning it with an explicit start
+     * offset.  This replaces the legacy rd_kafka_consume_start(); messages are
+     * then retrieved via rd_kafka_consumer_poll() in kafkaIterateForeignScan.
+     * We assign a single partition at a time to preserve the per-partition
+     * offset-range scan semantics.
+     */
     {
-        err = rd_kafka_last_error();
-        ereport(ERROR,
-                (errcode(ERRCODE_FDW_ERROR),
-                 errmsg_internal("kafka_fdw: Failed to start consuming: %s", rd_kafka_err2str(err))));
+        rd_kafka_topic_partition_list_t *tpl = rd_kafka_topic_partition_list_new(1);
+
+        rd_kafka_topic_partition_list_add(tpl, festate->kafka_options.topic, scan_p->partition)->offset =
+          MAX(low, scan_p->offset);
+
+        err = rd_kafka_assign(festate->kafka_handle, tpl);
+        rd_kafka_topic_partition_list_destroy(tpl);
+
+        if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
+            ereport(ERROR,
+                    (errcode(ERRCODE_FDW_ERROR),
+                     errmsg_internal("kafka_fdw: Failed to assign partition %d: %s",
+                                     scan_p->partition,
+                                     rd_kafka_err2str(err))));
     }
     return true;
 }

--- a/src/kafka_fdw.h
+++ b/src/kafka_fdw.h
@@ -262,6 +262,15 @@ void KafkaFdwGetConnection(KafkaOptions *k_options,
                            rd_kafka_t **kafka_handle,
                            rd_kafka_topic_t **kafka_topic_handle);
 
+/*
+ * Group-less high-level consumer used by the scan path: consumption is driven
+ * purely via rd_kafka_assign() + rd_kafka_consumer_poll(), no consumer group is
+ * joined and no offsets are committed.
+ */
+void KafkaFdwGetConsumer(KafkaOptions *k_options,
+                         rd_kafka_t **kafka_handle,
+                         rd_kafka_topic_t **kafka_topic_handle);
+
 void kafkaCloseConnection(KafkaFdwExecutionState *festate);
 
 /* option.c */


### PR DESCRIPTION
Move the foreign-scan read path off the deprecated simple/legacy consumer onto the high-level consumer